### PR TITLE
Relicense Enve under AGPL-3.0-only

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,4 +72,6 @@ Include:
 - screenshots or a short recording for visible UI changes
 - known limitations or follow-up work
 
-By contributing, you confirm that you have the right to submit the work and agree to the contribution terms in [LICENSE.md](LICENSE.md).
+## Contribution licensing
+
+Contributions are accepted on an inbound-equals-outbound basis. By intentionally submitting a contribution, you license it under the GNU Affero General Public License v3.0 only (`AGPL-3.0-only`) in [LICENSE.md](LICENSE.md). You retain ownership of your contribution. No separate contributor agreement grants Enve broader relicensing rights unless you separately agree to one in writing.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,132 +1,661 @@
-# Enve Noncommercial Public Source License
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
 
-Version 1.0, August 2026
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-Copyright © 2026 Isaac Lamb
+                            Preamble
 
-## 1. Acceptance
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
 
-By exercising any permission granted by this license, you agree to its terms. If you do not agree, you receive no rights under this license.
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
 
-## 2. Definitions
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
 
-"Software" means the Enve source code, build files, documentation, and original assets distributed with this license, excluding Third-Party Materials.
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
 
-"Licensor" means each copyright holder who offers their work under this license.
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
 
-"You" means the individual or legal entity exercising rights under this license.
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
 
-"Modified Version" means any work based on, incorporating, translating, adapting, or modifying any part of the Software.
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
 
-"Corresponding Source" means the complete preferred form for making modifications, including all source code, build scripts, project files, interface definitions, configuration examples, and instructions reasonably necessary to build and run the distributed or publicly operated version. Corresponding Source does not include credentials, signing certificates, private keys, personal data, or third-party services that the recipient can obtain independently.
+  The precise terms and conditions for copying, distribution and
+modification follow.
 
-"Commercial Purpose" means use primarily intended for or directed toward commercial advantage, monetary compensation, revenue, or the business operations of a for-profit entity. Commercial Purpose includes selling access or copies, paid distribution, subscriptions, required purchases, in-app purchases, advertising, sponsorship placements, affiliate revenue, paid bundling, monetized hosting, paid support tied to access, data monetization, and soliciting or accepting donations in connection with a copy or Modified Version.
+                       TERMS AND CONDITIONS
 
-"Advertising" means paid, sponsored, affiliate, promotional, or cross-promotional material added by a distributor or operator to generate revenue or commercial benefit. Copyright notices, source links, contributor credit, and noncommercial links to report issues are not Advertising.
+  0. Definitions.
 
-"Third-Party Materials" means components, libraries, media, trademarks, or other works identified as third-party material, including material in `LocalPackages`, `ThirdParty`, dependency packages, and files carrying separate license or attribution notices.
+  "This License" refers to version 3 of the GNU Affero General Public License.
 
-## 3. License Grant
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
 
-Subject to every condition in this license, the Licensor grants You a worldwide, royalty-free, nonexclusive, nontransferable copyright license to use, reproduce, modify, and distribute the Software solely for a permitted Noncommercial Purpose.
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
 
-The Licensor also grants You a patent license for patent claims the Licensor can license that are necessarily infringed by exercising the copyright permissions granted above. This patent license ends immediately if You or Your organization assert in writing that the Software infringes a patent.
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
 
-## 4. Permitted Purposes
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
 
-The following are permitted when they are not undertaken for a Commercial Purpose:
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
 
-1. Personal use, study, research, experimentation, accessibility work, and private entertainment.
-2. Hobbyist and community projects.
-3. Teaching and academic research by an educational institution.
-4. Use by a charitable, public-interest, public-safety, or governmental organization.
-5. Creating and distributing a Modified Version in full compliance with this license.
-6. Contributing changes to the official Enve project.
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
 
-Use by or for a for-profit business is not permitted, including internal business use, evaluation for anticipated commercial use, or development of a commercial product or service, unless the Licensor grants separate written permission.
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
 
-## 5. No Charging, Monetization, or Advertising
+  1. Source Code.
 
-You may not sell, rent, lease, sublicense, monetize, or charge any fee for the Software, a Modified Version, access to either, or a product or service whose value substantially derives from either.
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
 
-Every copy and Modified Version must be provided without Advertising and without payment, subscription, donation, purchase, account upgrade, commercial data collection, or other consideration.
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
 
-You may not remove features from a free copy in order to offer them through a paid copy, paid service, subscription, or purchase.
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
 
-## 6. Distribution and Public Operation
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
 
-You may distribute the Software or a Modified Version only if all of the following conditions are met:
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
 
-1. You provide the complete Corresponding Source at no charge through a publicly accessible location that does not require registration.
-2. The Corresponding Source is available no later than the first distribution of the copy or Modified Version and remains available for as long as that version is distributed, plus three years.
-3. You license the entire Modified Version under this exact license, without additional restrictions.
-4. You include this license, all copyright notices, all attribution notices, and all Third-Party Materials notices.
-5. You clearly identify the work as modified and provide a reasonable summary of material changes.
-6. You do not state or imply that the Modified Version is an official Enve release or is endorsed by the Licensor.
-7. You do not use the Enve name, logo, app icon, trade dress, or other brand assets except as reasonably necessary to describe compatibility or identify the origin of the Software.
-8. You comply with all applicable Third-Party Materials licenses.
+  The Corresponding Source for a work in source code form is that
+same work.
 
-If You make the Software or a Modified Version available for others to interact with remotely over a network, You must provide every user a prominent, convenient link to the complete Corresponding Source under the conditions above.
+  2. Basic Permissions.
 
-Distribution in executable or binary form without complete Corresponding Source is not permitted.
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
 
-## 7. Private Modifications
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
 
-You may make private modifications for Your own permitted personal use without publishing them. This exception ends when You distribute the modification, allow another person to use it, publicly deploy it, or make it available for remote interaction.
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
 
-## 8. Contributions
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
 
-Unless a separate written agreement states otherwise, by intentionally submitting a contribution for inclusion in the official Enve project, You certify that You have the right to submit it and grant the Licensor:
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
 
-1. A perpetual, worldwide, irrevocable, royalty-free copyright license to use, reproduce, modify, distribute, sublicense, and relicense the contribution for any purpose.
-2. A perpetual, worldwide, irrevocable, royalty-free patent license for patent claims You can license that are necessarily infringed by the contribution or its combination with the project.
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
 
-You retain ownership of Your contribution. The licenses above allow the official project to distribute releases under this license, operate official distribution channels, and offer separate licenses without requesting additional permission from each contributor.
+  4. Conveying Verbatim Copies.
 
-## 9. Licensor Rights and Separate Licenses
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
 
-This license limits licensees, not a copyright holder's exercise of their own rights. The Licensor may distribute the Software through official channels, accept voluntary support, offer separate commercial licenses, or license the Software to others under different terms.
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
 
-No contributor may represent themselves as the Licensor or grant exceptions for rights they do not own.
+  5. Conveying Modified Source Versions.
 
-## 10. Third-Party Materials
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
 
-This license does not replace, limit, or expand any license governing Third-Party Materials. Third-Party Materials remain subject solely to their respective terms. If this license conflicts with a Third-Party Materials license, the third-party license controls only for that material.
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
 
-The restrictions in this license, including the restrictions on commercial use, charging, monetization, advertising, sublicensing, and redistribution, do not apply to Third-Party Materials when their respective licenses grant those rights. Those rights apply only to the Third-Party Materials and do not extend to the Software.
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
 
-When a Third-Party Materials license requires recipients to be able to modify, replace, reverse engineer, debug, recombine, or relink that material with the Software, the Licensor grants the minimum additional permission necessary to exercise those rights for a recipient's own lawful use. This includes permission to reverse engineer the combined executable solely to debug modifications to the Third-Party Materials and permission to rebuild or relink the Software with a modified, interface-compatible version of those materials. This permission does not authorize commercial use or distribution of the Software and does not remove any other condition of this license.
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
 
-When distributing a version that contains Third-Party Materials, the distributor must provide every license, notice, source archive, modification notice, build script, object file, installation detail, or relinking material required by the applicable third-party license. These materials must correspond exactly to the distributed version and must be offered in the manner and for the period required by that license.
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
 
-Recipients receive rights in Third-Party Materials directly under their respective licenses. No distributor may impose this license or any additional restriction on rights granted by those licenses.
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
 
-Nothing in this license grants rights to third-party names, logos, service marks, media, or other trademarks.
+  6. Conveying Non-Source Forms.
 
-## 11. No Trademark License
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
 
-This license grants no permission to use the Enve name, logos, icons, or trade dress as a trademark or brand. Descriptive references such as "based on Enve" are permitted only when accurate, noncommercial, and not misleading.
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
 
-## 12. Compliance and Termination
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
 
-Your rights end automatically when You violate this license. If this is Your first violation and You fully correct it within thirty days after receiving written notice from a copyright holder, Your rights are reinstated provisionally and become permanent if the copyright holder does not notify You of another violation within sixty days after reinstatement.
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
 
-Sections intended by their nature to survive termination remain effective, including attribution, warranty, liability, and obligations arising from prior distribution.
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
 
-## 13. No Warranty
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
 
-TO THE MAXIMUM EXTENT PERMITTED BY LAW, THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT. YOU BEAR ALL RISK ARISING FROM USE OR DISTRIBUTION OF THE SOFTWARE.
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
 
-## 14. Limitation of Liability
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
 
-TO THE MAXIMUM EXTENT PERMITTED BY LAW, NO LICENSOR OR CONTRIBUTOR WILL BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, CONSEQUENTIAL, OR OTHER DAMAGES ARISING FROM THE SOFTWARE OR THIS LICENSE, REGARDLESS OF THE LEGAL THEORY AND EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
 
-## 15. Severability and Entire License
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
 
-If any provision is held unenforceable, it will be reformed only to the minimum extent necessary, and the remaining provisions will continue in effect.
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
 
-This license is the entire agreement for the rights it grants unless You and the applicable copyright holder enter into a separate written agreement.
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
 
-## Required Notice
+  7. Additional Terms.
 
-Enve is source-available software. Commercial use, paid redistribution, monetization, advertising, and closed-source forks are prohibited.
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -6,7 +6,7 @@ Source provenance identifier: `enve-source-7f6167c5-3bdb-4a0d-91b8-0e5e30f1e9c4`
 
 Android source provenance identifier: `enve-android-source-cc91a725-7756-4324-a504-e063bcecbfe0`
 
-Copyright 2026 Isaac Lamb. Enve's original source is distributed under the Enve Noncommercial Public Source License in `LICENSE.md`. Redistributed copies and forks must retain the required license and attribution notices.
+Copyright 2026 Isaac Lamb. Enve's original source is distributed under the GNU Affero General Public License v3.0 only (`AGPL-3.0-only`) in `LICENSE.md`. Redistributed copies and forks must comply with the AGPL and retain the required license and attribution notices.
 
 Third-party source, packages, frameworks, artwork, and other materials remain under their own licenses and copyrights. Their inclusion does not relicense them under the Enve license. Review the platform package manifests, lockfiles, `ThirdParty/`, `BuildSupport/`, and local packages before distributing a build or source archive.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <a href="https://github.com/opisaac9001/Enve-Book-Player/discussions"><img src="https://img.shields.io/badge/GitHub-Discussions-24292F?style=for-the-badge&logo=github" alt="GitHub Discussions"></a>
   <a href="https://discord.gg/Hw4nmXRehb"><img src="https://img.shields.io/badge/Discord-community-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Join the Discord community"></a>
   <a href="https://buymeacoffee.com/envebookplayer"><img src="https://img.shields.io/badge/Buy%20Me%20a%20Coffee-support-FFDD00?style=for-the-badge&logo=buymeacoffee&logoColor=000000" alt="Support Enve on Buy Me a Coffee"></a>
-  <a href="./LICENSE.md"><img src="https://img.shields.io/badge/license-source--available-1F2937?style=for-the-badge" alt="Source-available license"></a>
+  <a href="./LICENSE.md"><img src="https://img.shields.io/badge/license-AGPL--3.0--only-663399?style=for-the-badge" alt="AGPL-3.0-only license"></a>
 </p>
 
 Enve brings listening and reading together without requiring an Enve account, subscription, or cloud service. Connect the servers you already run, import local files, and keep your library and progress under your control.
@@ -208,6 +208,6 @@ Thank you for directly supporting Enve's continued development.
 
 ## License
 
-Enve is **source-available**, not OSI open source. It is distributed under the [Enve Noncommercial Public Source License](LICENSE.md). Personal use, study, modification, and noncommercial community contributions are permitted. Commercial use, paid redistribution, advertising, monetization, and closed-source forks are prohibited.
+Enve's original source is free and open-source software under the [GNU Affero General Public License v3.0 only](LICENSE.md) (`AGPL-3.0-only`). Commercial use and paid redistribution are permitted, provided the AGPL's source-disclosure, notice, and reciprocal-licensing requirements are met.
 
 [Third-party notices](THIRD_PARTY_NOTICES.md) list the licenses and attribution requirements for dependencies, bundled resources, and provider artwork. They are legal notices for redistribution, not additional setup instructions.

--- a/android/CONTRIBUTING.md
+++ b/android/CONTRIBUTING.md
@@ -54,4 +54,6 @@ Automated output is not verification. Disclose meaningful AI assistance in the p
 
 Explain the user-visible outcome, important implementation choices, exact verification performed, known limitations, and meaningful AI assistance. Do not rewrite a maintainer's branch or include unrelated formatting.
 
-By contributing, you agree that your contribution is distributed under `LICENSE.md` as described in its contribution section.
+## Contribution licensing
+
+Contributions are accepted on an inbound-equals-outbound basis. By intentionally submitting a contribution, you license it under the GNU Affero General Public License v3.0 only (`AGPL-3.0-only`) in `LICENSE.md`. You retain ownership of your contribution. No separate contributor agreement grants Enve broader relicensing rights unless you separately agree to one in writing.

--- a/android/LICENSE.md
+++ b/android/LICENSE.md
@@ -1,132 +1,661 @@
-# Enve Noncommercial Public Source License
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
 
-Version 1.0, August 2026
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-Copyright © 2026 Isaac Lamb
+                            Preamble
 
-## 1. Acceptance
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
 
-By exercising any permission granted by this license, you agree to its terms. If you do not agree, you receive no rights under this license.
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
 
-## 2. Definitions
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
 
-"Software" means the Enve source code, build files, documentation, and original assets distributed with this license, excluding Third-Party Materials.
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
 
-"Licensor" means each copyright holder who offers their work under this license.
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
 
-"You" means the individual or legal entity exercising rights under this license.
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
 
-"Modified Version" means any work based on, incorporating, translating, adapting, or modifying any part of the Software.
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
 
-"Corresponding Source" means the complete preferred form for making modifications, including all source code, build scripts, project files, interface definitions, configuration examples, and instructions reasonably necessary to build and run the distributed or publicly operated version. Corresponding Source does not include credentials, signing certificates, private keys, personal data, or third-party services that the recipient can obtain independently.
+  The precise terms and conditions for copying, distribution and
+modification follow.
 
-"Commercial Purpose" means use primarily intended for or directed toward commercial advantage, monetary compensation, revenue, or the business operations of a for-profit entity. Commercial Purpose includes selling access or copies, paid distribution, subscriptions, required purchases, in-app purchases, advertising, sponsorship placements, affiliate revenue, paid bundling, monetized hosting, paid support tied to access, data monetization, and soliciting or accepting donations in connection with a copy or Modified Version.
+                       TERMS AND CONDITIONS
 
-"Advertising" means paid, sponsored, affiliate, promotional, or cross-promotional material added by a distributor or operator to generate revenue or commercial benefit. Copyright notices, source links, contributor credit, and noncommercial links to report issues are not Advertising.
+  0. Definitions.
 
-"Third-Party Materials" means components, libraries, media, trademarks, or other works identified as third-party material, including material in `ThirdParty`, Gradle dependencies, native dependencies, and files carrying separate license or attribution notices.
+  "This License" refers to version 3 of the GNU Affero General Public License.
 
-## 3. License Grant
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
 
-Subject to every condition in this license, the Licensor grants You a worldwide, royalty-free, nonexclusive, nontransferable copyright license to use, reproduce, modify, and distribute the Software solely for a permitted Noncommercial Purpose.
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
 
-The Licensor also grants You a patent license for patent claims the Licensor can license that are necessarily infringed by exercising the copyright permissions granted above. This patent license ends immediately if You or Your organization assert in writing that the Software infringes a patent.
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
 
-## 4. Permitted Purposes
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
 
-The following are permitted when they are not undertaken for a Commercial Purpose:
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
 
-1. Personal use, study, research, experimentation, accessibility work, and private entertainment.
-2. Hobbyist and community projects.
-3. Teaching and academic research by an educational institution.
-4. Use by a charitable, public-interest, public-safety, or governmental organization.
-5. Creating and distributing a Modified Version in full compliance with this license.
-6. Contributing changes to the official Enve project.
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
 
-Use by or for a for-profit business is not permitted, including internal business use, evaluation for anticipated commercial use, or development of a commercial product or service, unless the Licensor grants separate written permission.
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
 
-## 5. No Charging, Monetization, or Advertising
+  1. Source Code.
 
-You may not sell, rent, lease, sublicense, monetize, or charge any fee for the Software, a Modified Version, access to either, or a product or service whose value substantially derives from either.
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
 
-Every copy and Modified Version must be provided without Advertising and without payment, subscription, donation, purchase, account upgrade, commercial data collection, or other consideration.
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
 
-You may not remove features from a free copy in order to offer them through a paid copy, paid service, subscription, or purchase.
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
 
-## 6. Distribution and Public Operation
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
 
-You may distribute the Software or a Modified Version only if all of the following conditions are met:
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
 
-1. You provide the complete Corresponding Source at no charge through a publicly accessible location that does not require registration.
-2. The Corresponding Source is available no later than the first distribution of the copy or Modified Version and remains available for as long as that version is distributed, plus three years.
-3. You license the entire Modified Version under this exact license, without additional restrictions.
-4. You include this license, all copyright notices, all attribution notices, and all Third-Party Materials notices.
-5. You clearly identify the work as modified and provide a reasonable summary of material changes.
-6. You do not state or imply that the Modified Version is an official Enve release or is endorsed by the Licensor.
-7. You do not use the Enve name, logo, app icon, trade dress, or other brand assets except as reasonably necessary to describe compatibility or identify the origin of the Software.
-8. You comply with all applicable Third-Party Materials licenses.
+  The Corresponding Source for a work in source code form is that
+same work.
 
-If You make the Software or a Modified Version available for others to interact with remotely over a network, You must provide every user a prominent, convenient link to the complete Corresponding Source under the conditions above.
+  2. Basic Permissions.
 
-Distribution in executable or binary form without complete Corresponding Source is not permitted.
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
 
-## 7. Private Modifications
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
 
-You may make private modifications for Your own permitted personal use without publishing them. This exception ends when You distribute the modification, allow another person to use it, publicly deploy it, or make it available for remote interaction.
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
 
-## 8. Contributions
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
 
-Unless a separate written agreement states otherwise, by intentionally submitting a contribution for inclusion in the official Enve project, You certify that You have the right to submit it and grant the Licensor:
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
 
-1. A perpetual, worldwide, irrevocable, royalty-free copyright license to use, reproduce, modify, distribute, sublicense, and relicense the contribution for any purpose.
-2. A perpetual, worldwide, irrevocable, royalty-free patent license for patent claims You can license that are necessarily infringed by the contribution or its combination with the project.
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
 
-You retain ownership of Your contribution. The licenses above allow the official project to distribute releases under this license, operate official distribution channels, and offer separate licenses without requesting additional permission from each contributor.
+  4. Conveying Verbatim Copies.
 
-## 9. Licensor Rights and Separate Licenses
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
 
-This license limits licensees, not a copyright holder's exercise of their own rights. The Licensor may distribute the Software through official channels, accept voluntary support, offer separate commercial licenses, or license the Software to others under different terms.
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
 
-No contributor may represent themselves as the Licensor or grant exceptions for rights they do not own.
+  5. Conveying Modified Source Versions.
 
-## 10. Third-Party Materials
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
 
-This license does not replace, limit, or expand any license governing Third-Party Materials. Third-Party Materials remain subject solely to their respective terms. If this license conflicts with a Third-Party Materials license, the third-party license controls only for that material.
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
 
-The restrictions in this license, including the restrictions on commercial use, charging, monetization, advertising, sublicensing, and redistribution, do not apply to Third-Party Materials when their respective licenses grant those rights. Those rights apply only to the Third-Party Materials and do not extend to the Software.
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
 
-When a Third-Party Materials license requires recipients to be able to modify, replace, reverse engineer, debug, recombine, or relink that material with the Software, the Licensor grants the minimum additional permission necessary to exercise those rights for a recipient's own lawful use. This includes permission to reverse engineer the combined executable solely to debug modifications to the Third-Party Materials and permission to rebuild or relink the Software with a modified, interface-compatible version of those materials. This permission does not authorize commercial use or distribution of the Software and does not remove any other condition of this license.
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
 
-When distributing a version that contains Third-Party Materials, the distributor must provide every license, notice, source archive, modification notice, build script, object file, installation detail, or relinking material required by the applicable third-party license. These materials must correspond exactly to the distributed version and must be offered in the manner and for the period required by that license.
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
 
-Recipients receive rights in Third-Party Materials directly under their respective licenses. No distributor may impose this license or any additional restriction on rights granted by those licenses.
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
 
-Nothing in this license grants rights to third-party names, logos, service marks, media, or other trademarks.
+  6. Conveying Non-Source Forms.
 
-## 11. No Trademark License
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
 
-This license grants no permission to use the Enve name, logos, icons, or trade dress as a trademark or brand. Descriptive references such as "based on Enve" are permitted only when accurate, noncommercial, and not misleading.
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
 
-## 12. Compliance and Termination
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
 
-Your rights end automatically when You violate this license. If this is Your first violation and You fully correct it within thirty days after receiving written notice from a copyright holder, Your rights are reinstated provisionally and become permanent if the copyright holder does not notify You of another violation within sixty days after reinstatement.
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
 
-Sections intended by their nature to survive termination remain effective, including attribution, warranty, liability, and obligations arising from prior distribution.
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
 
-## 13. No Warranty
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
 
-TO THE MAXIMUM EXTENT PERMITTED BY LAW, THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT. YOU BEAR ALL RISK ARISING FROM USE OR DISTRIBUTION OF THE SOFTWARE.
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
 
-## 14. Limitation of Liability
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
 
-TO THE MAXIMUM EXTENT PERMITTED BY LAW, NO LICENSOR OR CONTRIBUTOR WILL BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, CONSEQUENTIAL, OR OTHER DAMAGES ARISING FROM THE SOFTWARE OR THIS LICENSE, REGARDLESS OF THE LEGAL THEORY AND EVEN IF ADVISED OF THE POSSIBILITY.
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
 
-## 15. Severability and Entire License
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
 
-If any provision is held unenforceable, it will be reformed only to the minimum extent necessary, and the remaining provisions will continue in effect.
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
 
-This license is the entire agreement for the rights it grants unless You and the applicable copyright holder enter into a separate written agreement.
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
 
-## Required Notice
+  7. Additional Terms.
 
-Enve is source-available software. Commercial use, paid redistribution, monetization, advertising, and closed-source forks are prohibited.
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/android/NOTICE.md
+++ b/android/NOTICE.md
@@ -4,7 +4,7 @@ Enve Book Player is an original project maintained by Isaac Lamb.
 
 Source provenance identifier: `enve-android-source-cc91a725-7756-4324-a504-e063bcecbfe0`
 
-Copyright 2026 Isaac Lamb. Enve's original source is distributed under the Enve Noncommercial Public Source License in `LICENSE.md`. Redistributed copies and forks must retain the required license and attribution notices.
+Copyright 2026 Isaac Lamb. Enve's original source is distributed under the GNU Affero General Public License v3.0 only (`AGPL-3.0-only`) in `LICENSE.md`. Redistributed copies and forks must comply with the AGPL and retain the required license and attribution notices.
 
 Third-party source, Gradle dependencies, native libraries, artwork, trademarks, and other materials remain under their own licenses and copyrights. Their inclusion does not relicense them under the Enve license. Review the Gradle build files, `ThirdParty/`, `BuildSupport/`, native source directories, and bundled brand documentation before distributing a build or source archive.
 

--- a/android/README.md
+++ b/android/README.md
@@ -50,6 +50,6 @@ See [DEVELOPMENT.md](DEVELOPMENT.md) for setup and architecture details. Read [C
 
 ## License
 
-Enve is source-available under the [Enve Noncommercial Public Source License](LICENSE.md). Commercial use, paid redistribution, advertising, monetization, and closed-source forks are prohibited. This is not an OSI-approved open-source license.
+Enve's original source is free and open-source software under the [GNU Affero General Public License v3.0 only](LICENSE.md) (`AGPL-3.0-only`). Commercial use and paid redistribution are permitted, provided the AGPL's source-disclosure, notice, and reciprocal-licensing requirements are met.
 
 Third-party components remain under their respective licenses. Redistributions must retain [NOTICE.md](NOTICE.md), [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md), and the license files shipped with vendored components. The [third-party audit](docs/legal/THIRD_PARTY_AUDIT.md) lists requirements that must be resolved before distributing an APK or app bundle.

--- a/android/docs/legal/THIRD_PARTY_AUDIT.md
+++ b/android/docs/legal/THIRD_PARTY_AUDIT.md
@@ -6,7 +6,7 @@ This is a release checklist, not legal advice. It separates source publication f
 
 ## Current conclusion
 
-The source repository can be published under the Enve Noncommercial Public Source License because `LICENSE.md` excludes third-party materials and preserves their separate rights. The repository-level licensing work is complete; a public APK or app bundle remains gated on verification of the exact signed release candidate and its matching public source snapshot.
+Enve's original source can be published under the GNU Affero General Public License v3.0 only (`AGPL-3.0-only`). Third-party materials remain under their own terms. A public APK or app bundle remains gated on an AGPL compatibility review of every linked and bundled dependency, verification of the exact signed release candidate, and publication of its matching source snapshot.
 
 The remaining binary release gates are:
 
@@ -18,7 +18,7 @@ The remaining binary release gates are:
 
 ## Source repository checks
 
-- [x] Root Enve license distinguishes original and third-party material.
+- [x] Root notices distinguish Enve's original source from third-party material.
 - [x] Root notice carries an Android-specific provenance identifier.
 - [x] Foliate is pinned as a Git submodule and its runtime is built from an allowlist.
 - [x] Foliate and zip.js licenses are copied into generated assets.
@@ -62,13 +62,13 @@ A release evidence bundle should contain:
 - a report from inspecting the final APK and app bundle
 - the private source revision, matching public source revision, and confirmation that Android Auto is present in the public snapshot
 
-Keep that bundle available for at least the period required by the applicable licenses and by section 6 of the Enve license.
+Keep that bundle available for at least the period required by the applicable licenses and by section 6 of the AGPL.
 
 ## License compatibility notes
 
-The Enve license's noncommercial and advertising restrictions apply only to Enve-owned material. They do not restrict rights granted in libmobi, jcifs-ng, Foliate, AndroidX, or other third-party components.
+The AGPL applies to Enve's original source. Third-party materials retain their own licenses, but distributing a combined APK or app bundle requires those terms to be compatible with the AGPL's obligations. Keeping separate notices does not establish compatibility.
 
-LGPL recipients must retain the right to modify the covered library and debug those modifications. The Enve license explicitly grants the minimum reverse-engineering and relinking permission necessary for third-party compliance, but a distributor still has to provide the practical materials required by the LGPL.
+LGPL recipients must retain the right to modify the covered library and debug those modifications. A distributor must provide the practical materials required by the LGPL and satisfy the AGPL independently.
 
 Google SDK and model terms may impose service, telemetry, account, privacy, or acceptable-use conditions. Those terms are not converted into the Enve license and must be evaluated for the actual release channel.
 

--- a/android/scripts/verify-provenance
+++ b/android/scripts/verify-provenance
@@ -16,7 +16,7 @@ require_text() {
     fi
 }
 
-require_text LICENSE.md 'Enve Noncommercial Public Source License'
+require_text LICENSE.md 'GNU AFFERO GENERAL PUBLIC LICENSE'
 require_text NOTICE.md "$identifier"
 require_text THIRD_PARTY_NOTICES.md '## Distribution reminder'
 require_text docs/legal/THIRD_PARTY_AUDIT.md '## Current conclusion'

--- a/ios/README.md
+++ b/ios/README.md
@@ -15,7 +15,7 @@
   <a href="https://github.com/opisaac9001/Enve-Book-Player/discussions"><img src="https://img.shields.io/badge/GitHub-Discussions-24292F?style=for-the-badge&logo=github" alt="GitHub Discussions"></a>
   <a href="https://discord.gg/Hw4nmXRehb"><img src="https://img.shields.io/badge/Discord-community-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Join the Discord community"></a>
   <a href="https://buymeacoffee.com/envebookplayer"><img src="https://img.shields.io/badge/Buy%20Me%20a%20Coffee-support-FFDD00?style=for-the-badge&logo=buymeacoffee&logoColor=000000" alt="Support Enve on Buy Me a Coffee"></a>
-  <a href="../LICENSE.md"><img src="https://img.shields.io/badge/license-source--available-1F2937?style=for-the-badge" alt="Source-available license"></a>
+  <a href="../LICENSE.md"><img src="https://img.shields.io/badge/license-AGPL--3.0--only-663399?style=for-the-badge" alt="AGPL-3.0-only license"></a>
 </p>
 
 Enve brings listening and reading together without requiring an Enve account, subscription, or cloud service. Connect the servers you already run, import local files, and keep your library and progress under your control.
@@ -114,6 +114,6 @@ Files beginning with `// AGENT-LOCKED` have extra safeguards because they are ea
 
 ## License
 
-Enve is **source-available**, not OSI open source. It is distributed under the [Enve Noncommercial Public Source License](../LICENSE.md). Personal use, study, modification, and noncommercial community contributions are permitted. Commercial use, paid redistribution, advertising, monetization, and closed-source forks are prohibited.
+Enve's original source is free and open-source software under the [GNU Affero General Public License v3.0 only](../LICENSE.md) (`AGPL-3.0-only`). Commercial use and paid redistribution are permitted, provided the AGPL's source-disclosure, notice, and reciprocal-licensing requirements are met.
 
 [Third-party notices](THIRD_PARTY_NOTICES.md) list the licenses and attribution requirements for dependencies, bundled resources, and provider artwork. They are legal notices for redistribution, not additional setup instructions.

--- a/ios/docs/distribution/public-source-release.md
+++ b/ios/docs/distribution/public-source-release.md
@@ -1,6 +1,6 @@
 # Public Source Release Runbook
 
-This runbook publishes a stable source snapshot from the private development repository to the public source repository. Enve is source-available under the Enve Noncommercial Public Source License, not OSI open source.
+This runbook publishes a stable source snapshot from the private development repository to the public source repository. Enve's original source is free and open-source software under the GNU Affero General Public License v3.0 only (`AGPL-3.0-only`). Third-party materials remain under their respective licenses.
 
 ## Repository roles
 

--- a/ios/docs/legal/THIRD_PARTY_AUDIT.md
+++ b/ios/docs/legal/THIRD_PARTY_AUDIT.md
@@ -6,9 +6,9 @@ This is an engineering compliance inventory, not legal advice. It separates publ
 
 ## Current conclusion
 
-The code, dependency source, and current provider artwork can be published with the existing license files and the root `THIRD_PARTY_NOTICES.md`. The maintainer confirms that the provider logos are authorized for their current identification and compatibility use in Enve. A signed binary is not ready for distribution as-is because most compiled-package notices are not bundled or exposed to users, the LGPL delivery plan is incomplete, and optional model terms are not presented at download time.
+Enve's original source can be published under the GNU Affero General Public License v3.0 only (`AGPL-3.0-only`) with the existing notice files. Third-party source and artwork remain under their own terms. The maintainer confirms that the provider logos are authorized for their current identification and compatibility use in Enve. A signed binary is not ready for distribution as-is because compatibility has not been established between the AGPL and the App Store distribution terms or every linked and bundled dependency, most compiled-package notices are not bundled or exposed to users, the LGPL delivery plan is incomplete, and optional model terms are not presented at download time.
 
-Enve's license prohibits commercial use, charging, advertising, and monetization. Those restrictions conflict with the Open Source Definition's free-redistribution and no-discrimination-against-fields-of-endeavor requirements. Public materials should describe Enve as **source-available**, not OSI open source. See the [Open Source Definition](https://opensource.org/osd).
+Enve's original source is licensed under the OSI-approved GNU Affero General Public License v3.0 only. The AGPL permits commercial use and redistribution while requiring covered source disclosure and reciprocal licensing in the circumstances defined by the license. Public materials may describe Enve's original source as open-source software. Do not apply that description or the AGPL to third-party materials governed by different terms.
 
 ## Dependency findings
 

--- a/ios/scripts/verify-provenance
+++ b/ios/scripts/verify-provenance
@@ -16,7 +16,7 @@ require_text() {
     fi
 }
 
-require_text ../LICENSE.md 'Enve Noncommercial Public Source License'
+require_text ../LICENSE.md 'GNU AFFERO GENERAL PUBLIC LICENSE'
 require_text ../NOTICE.md "$identifier"
 require_text THIRD_PARTY_NOTICES.md '## Distribution reminder'
 require_text docs/legal/THIRD_PARTY_AUDIT.md '## Current conclusion'


### PR DESCRIPTION
## Summary
- replace the custom noncommercial license with GNU AGPL v3.0 only
- document AGPL inbound-equals-outbound contribution terms
- update iOS and Android license notices, public documentation, and provenance checks
- record that binary distribution still requires platform and dependency compatibility review

## Verification
- iOS provenance and agent-lock verification passed
- Android provenance, asset digest, and agent-lock verification passed
- license text matches the verified GNU AGPL v3 text used by Grimmory
- documentation-only change; no application behavior changed