### PR TITLE
Update iOS 1.2.2 and Android build 50 source snapshots

### DIFF
--- a/android/CHANGELOG.md
+++ b/android/CHANGELOG.md
@@ -6,6 +6,15 @@ Release notes for the Android app. Versions are `<name> build <code>`, matching 
 
 No pending changes.
 
+## 1.2 build 50 — 2026-09-08
+
+- Preserve square audiobook artwork throughout the app and match reader backgrounds to the selected reading theme.
+- Protect newer local listening positions and pending uploads during Audiobookshelf refreshes.
+- Add Library and Downloads shelves to Android Auto and chapter queues for single-file audiobooks.
+- Add on-device FB2-to-EPUB conversion and allow valid small ebook files.
+- Correct BookOrbit series numbering, Grimmory download URLs, and anonymous OPDS sign-in.
+- Serialize proactive and expired-token refreshes through a shared coordinator.
+
 ## 1.2 build 46 — 2026-08-29
 
 ### Added

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -126,8 +126,8 @@ android {
         applicationId = "com.enve.app"
         minSdk = 26
         targetSdk = 36
-        versionCode = 46
-        versionName = "1.2 build 46"
+        versionCode = 50
+        versionName = "1.2 build 50"
         buildConfigField(
             "String",
             "SOURCE_PROVENANCE",

--- a/android/app/src/androidTest/java/com/enve/app/data/local/BookCacheDaoTest.kt
+++ b/android/app/src/androidTest/java/com/enve/app/data/local/BookCacheDaoTest.kt
@@ -6,6 +6,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.enve.core.data.local.BookCacheDao
 import com.enve.core.data.local.CachedBook
+import com.enve.core.data.local.PendingProgressPush
 import com.enve.core.data.local.BookMetadataOverride
 import com.enve.core.data.local.BookMetadataOverrideDao
 import com.enve.core.data.local.CustomSmartCollection
@@ -467,6 +468,100 @@ class BookCacheDaoTest {
         customSmartCollectionDao.delete("smart-1")
         assertEquals(0, customSmartCollectionDao.getAll().size)
     }
+
+    @Test
+    fun remoteProgressDoesNotReplaceNewerLocalListening() = runBlocking {
+        val local = cachedBook("audio", mediaType = "AUDIOBOOK").copy(
+            source = "AUDIOBOOKSHELF", currentTime = 900L, lastReadTime = 3000L,
+        )
+        dao.upsert(listOf(local))
+
+        assertEquals(0, applyRemoteAudio(updatedAt = 2000L))
+        assertEquals(0, applyRemoteAudio(updatedAt = 3000L))
+        assertEquals(0, applyRemoteAudio(updatedAt = 0L))
+        assertEquals(local, dao.getByCacheKey(local.cacheKey))
+    }
+
+    @Test
+    fun remoteProgressPreservesPendingLocalUpload() = runBlocking {
+        val local = cachedBook("audio").copy(source = "AUDIOBOOKSHELF", currentTime = 900L)
+        dao.upsert(listOf(local))
+        db.pendingProgressPushDao().upsert(PendingProgressPush(
+            bookId = "audio", source = "AUDIOBOOKSHELF", connectionKey = "test-conn",
+            mediaType = "AUDIOBOOK", percentage = 0.9f, isFinished = false, createdAt = 1000L,
+        ))
+
+        assertEquals(0, applyRemoteAudio(updatedAt = 2000L))
+        assertEquals(local, dao.getByCacheKey(local.cacheKey))
+    }
+
+    @Test
+    fun remoteProgressIsIsolatedByConnectionAndPreservesDownload() = runBlocking {
+        val other = cachedBook("audio", connectionId = "other").copy(source = "AUDIOBOOKSHELF")
+        dao.upsert(listOf(
+            cachedBook("audio", isDownloaded = true).copy(source = "AUDIOBOOKSHELF"), other,
+        ))
+        db.pendingProgressPushDao().upsert(PendingProgressPush(
+            bookId = "audio", source = "AUDIOBOOKSHELF", connectionKey = "other",
+            mediaType = "AUDIOBOOK", percentage = 0.9f, isFinished = false, createdAt = 1000L,
+        ))
+
+        assertEquals(1, applyRemoteAudio(updatedAt = 2000L))
+        val updated = dao.getByCacheKey("test-conn:audio")!!
+        assertEquals(120L, updated.currentTime)
+        assertEquals(2000L, updated.lastReadTime)
+        assertEquals(true, updated.isDownloaded)
+        assertEquals(true, updated.inProgress)
+        assertEquals(other, dao.getByCacheKey(other.cacheKey))
+    }
+
+    @Test
+    fun newerRemoteResetClearsPositionAndFinishedState() = runBlocking {
+        dao.upsert(listOf(cachedBook("audio").copy(
+            source = "AUDIOBOOKSHELF", currentTime = 900L, isFinished = true,
+            serverReadStatus = "READ", lastReadTime = 1000L, epubLocator = "old-locator",
+        )))
+
+        assertEquals(1, applyRemoteAudio(updatedAt = 2000L, position = 0L, progress = 0f))
+        val updated = dao.getByCacheKey("test-conn:audio")!!
+        assertEquals(0L, updated.currentTime)
+        assertEquals(false, updated.isFinished)
+        assertEquals(false, updated.inProgress)
+        assertNull(updated.epubLocator)
+        assertNull(updated.serverReadStatus)
+    }
+
+    @Test
+    fun remoteCompletionRemovesBookFromContinueListening() = runBlocking {
+        dao.upsert(listOf(cachedBook("audio").copy(
+            source = "AUDIOBOOKSHELF", currentTime = 120L, inProgress = true,
+        )))
+
+        assertEquals(1, dao.applyRemoteProgress(
+            cacheKey = "test-conn:audio", source = "AUDIOBOOKSHELF",
+            progress = 0.5f, ebookProgress = null, currentTimeSec = 120L,
+            locatorJson = null, finished = true, readStatus = null, updatedAt = 2000L,
+        ))
+        val updated = dao.getByCacheKey("test-conn:audio")!!
+        assertEquals(true, updated.isFinished)
+        assertEquals(false, updated.inProgress)
+    }
+
+    @Test
+    fun insertingRemoteDiscoveryDoesNotReplaceExistingLocalBook() = runBlocking {
+        val local = cachedBook("audio", isDownloaded = true).copy(currentTime = 900L)
+        dao.upsert(listOf(local))
+
+        assertEquals(-1L, dao.insertIfAbsent(cachedBook("audio")))
+        assertEquals(local, dao.getByCacheKey(local.cacheKey))
+    }
+
+    private suspend fun applyRemoteAudio(updatedAt: Long, position: Long = 120L, progress: Float = 0.2f) =
+        dao.applyRemoteProgress(
+            cacheKey = "test-conn:audio", source = "AUDIOBOOKSHELF",
+            progress = progress, ebookProgress = null, currentTimeSec = position,
+            locatorJson = null, finished = false, readStatus = null, updatedAt = updatedAt,
+        )
 
     private fun cachedBook(
         id: String,

--- a/android/app/src/androidTest/java/com/enve/app/data/sync/RecentlyPlayedSyncServiceTest.kt
+++ b/android/app/src/androidTest/java/com/enve/app/data/sync/RecentlyPlayedSyncServiceTest.kt
@@ -1,0 +1,66 @@
+package com.enve.app.data.sync
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.enve.core.data.sync.ProviderSyncResult
+import com.enve.core.data.sync.ProviderSyncStrategy
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class RecentlyPlayedSyncServiceTest {
+    @Test
+    fun reportsPartialFailureAlongsideSuccessfulMerges() = runBlocking {
+        val service = RecentlyPlayedSyncService(setOf(strategy("ABS") {
+            ProviderSyncResult(2, 0, listOf("Audiobookshelf"))
+        }))
+
+        val result = service.syncOnLaunch()
+
+        assertEquals(2, result.pulledItemCount)
+        assertEquals(listOf("Audiobookshelf"), result.failedStrategies)
+        assertTrue(result.hasFailures)
+    }
+
+    @Test
+    fun cancellationStopsDispatchInsteadOfReportingFailure() = runBlocking {
+        var nextCalled = false
+        val cancellation = CancellationException("cancelled")
+        val service = RecentlyPlayedSyncService(linkedSetOf(
+            strategy("cancelled") { throw cancellation },
+            strategy("next") { nextCalled = true; ProviderSyncResult.ZERO },
+        ))
+
+        val error = try {
+            service.syncOnLaunch()
+            null
+        } catch (e: CancellationException) {
+            e
+        }
+
+        assertEquals(cancellation, error)
+        assertEquals(false, nextCalled)
+    }
+
+    @Test
+    fun failedProviderDoesNotPreventAnotherProviderFromSyncing() = runBlocking {
+        val service = RecentlyPlayedSyncService(linkedSetOf(
+            strategy("failed") { error("unavailable") },
+            strategy("healthy") { ProviderSyncResult(3, 1) },
+        ))
+
+        val result = service.syncOnLaunch()
+
+        assertEquals(4, result.mergedItemCount)
+        assertEquals(listOf("failed"), result.failedStrategies)
+    }
+
+    private fun strategy(name: String, block: suspend () -> ProviderSyncResult) = object : ProviderSyncStrategy {
+        override val id = name
+        override val displayName = name
+        override suspend fun sync(force: Boolean, launchOptimized: Boolean) = block()
+    }
+}

--- a/android/app/src/androidTest/java/com/enve/app/playback/AndroidAutoMediaLibraryTest.kt
+++ b/android/app/src/androidTest/java/com/enve/app/playback/AndroidAutoMediaLibraryTest.kt
@@ -432,7 +432,7 @@ class AndroidAutoMediaLibraryTest {
                 ),
             )
             assertEquals(
-                MediaConstants.EXTRAS_VALUE_CONTENT_STYLE_GRID_ITEM,
+                MediaConstants.EXTRAS_VALUE_CONTENT_STYLE_LIST_ITEM,
                 rootResult.params?.extras?.getInt(
                     MediaConstants.EXTRAS_KEY_CONTENT_STYLE_PLAYABLE,
                 ),
@@ -447,19 +447,21 @@ class AndroidAutoMediaLibraryTest {
             assertEquals(
                 listOf(
                     AutoMediaBrowserHelper.SHELF_IN_PROGRESS,
+                    AutoMediaBrowserHelper.SHELF_LIBRARY,
+                    AutoMediaBrowserHelper.SHELF_DOWNLOADS,
                     AutoMediaBrowserHelper.SHELF_RECENT,
                 ),
                 shelves!!.map { it.mediaId },
             )
             assertEquals(
-                listOf("Continue Listening", "Recently Added"),
+                listOf("Continue Listening", "Library", "Downloads", "Recently Added"),
                 shelves.map { it.mediaMetadata.title.toString() },
             )
             assertEquals(
-                listOf("android.resource", "android.resource"),
+                listOf("android.resource", "android.resource", "android.resource", "android.resource"),
                 shelves.map { it.mediaMetadata.artworkUri?.scheme },
             )
-            assertEquals(2, shelves.map { it.mediaMetadata.artworkUri }.distinct().size)
+            assertEquals(4, shelves.map { it.mediaMetadata.artworkUri }.distinct().size)
 
             val recent = controllerHandler.call {
                 browser.getItem(AutoMediaBrowserHelper.SHELF_RECENT)

--- a/android/app/src/main/java/com/enve/app/ui/auth/AuthViewModel.kt
+++ b/android/app/src/main/java/com/enve/app/ui/auth/AuthViewModel.kt
@@ -40,12 +40,10 @@ data class QuickConnectUiState(
 )
 
 data class AuthState(
-    // Login form fields (not synced from preferences)
     val serverUrl: String = "",
     val username: String = "",
     val password: String = "",
 
-    // Currently active connection info (synced from preferences)
     val activeSource: BookSource = BookSource.GRIMMORY,
     val activeServerUrl: String = "",
     val activeUsername: String = "",
@@ -53,7 +51,6 @@ data class AuthState(
     val selectedSource: BookSource = BookSource.GRIMMORY,
     val editingConnectionId: String? = null,
     val browserAuthUrl: String? = null,
-    // Cookie name to poll for instead of waiting on a deep-link callback (Komga "SESSION").
     val browserAuthRequiredCookie: String? = null,
     val browserAuthRequiresOriginReturn: Boolean = false,
     val komgaOauthProvider: String = "",
@@ -64,20 +61,16 @@ data class AuthState(
     val isInitialized: Boolean = false,
     val showDiscordAnnouncement: Boolean = false,
     val error: String? = null,
-    // Plex PIN OAuth
     val plexPinId: Long = 0L,
     val plexPinCode: String = "",
     val plexPolling: Boolean = false,
-    // Plex Home user picker — populated when the user opens the switcher.
     val plexHomeUsers: List<com.enve.plex.auth.PlexHomeUser> = emptyList(),
     val plexHomeUsersLoading: Boolean = false,
     val plexHomeUsersError: String? = null,
     val plexCurrentUserId: Long? = null,
-    // Multi-service
     val allConnections: List<ProviderConnection> = emptyList(),
     val activeConnectionId: String? = null,
 
-    // Advanced connection options
     val urlScheme: UrlScheme = UrlScheme.HTTPS,
     val authMode: ConnectionAuthMode = ConnectionAuthMode.AUTO,
     val customHeaders: Map<String, String> = emptyMap(),
@@ -89,23 +82,17 @@ data class AuthState(
     val mtlsCertSubject: String? = null,
     val mtlsCertError: String? = null,
 
-    // Quick Connect (Jellyfin)
     val quickConnectCode: String = "",
     val quickConnectPolling: Boolean = false,
-    // Incremented on every successful login so the login screen can dismiss
-    // regardless of whether the user was already connected via another source.
-    // The prefs.isConnected approach breaks for multi-source because it's always true.
     val loginEpoch: Int = 0,
     val importMessage: String? = null,
     val cloudRootCandidates: List<String> = emptyList(),
     val selectedCloudRootPaths: List<String> = emptyList(),
     val pendingCloudRootConnectionId: String? = null,
 
-    // connectionHealth keyed by ProviderConnection.id; missing key = not yet probed.
     val isCheckingHealth: Boolean = false,
     val connectionHealth: Map<String, Boolean> = emptyMap(),
 ) {
-    // Effective headers merge: customHeaders + service tokens
     val effectiveHeaders: Map<String, String>
         get() {
             val merged = customHeaders.toMutableMap()
@@ -150,7 +137,6 @@ class AuthViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            // Run migration before anything else touches connection state
             runCatching { migrateOldSingleServerToConnectionRegistry() }
             runCatching { flagExpiredCloudflareCookies() }
             launch { runCatching { refreshKomgaAdminFlags() } }
@@ -188,8 +174,6 @@ class AuthViewModel @Inject constructor(
                         isInitialized = true,
                         allConnections = allConnections,
                         activeConnectionId = activeConnId,
-                        // Show the Discord announcement once: only for users upgrading to v10+
-                        // who haven't dismissed it yet. VERSION_CODE 10 = v1.3.
                         showDiscordAnnouncement = lastSeen < com.enve.app.BuildConfig.VERSION_CODE,
                     )
                 }
@@ -197,8 +181,6 @@ class AuthViewModel @Inject constructor(
         }
     }
 
-    // Migrate existing single-server users to the connection registry.
-    // Only runs once - after that the flag is set and we skip.
     private suspend fun migrateOldSingleServerToConnectionRegistry() {
         if (prefs.migrationCompleted.first()) return
 
@@ -227,7 +209,6 @@ class AuthViewModel @Inject constructor(
 
         connectionRegistry.upsert(connection)
 
-        // Copy legacy credentials to per-connection storage
         vault.put(CredentialVault.accessTokenKey(connectionId), oldAccessToken)
         if (oldUsername.isNotBlank()) {
             vault.put(CredentialVault.usernameKey(connectionId), oldUsername)
@@ -270,7 +251,6 @@ class AuthViewModel @Inject constructor(
 
     fun setSelectedSource(source: BookSource) {
         val defaultUrl = defaultServerUrlFor(source)
-        // Clear login fields when changing source to ensure a fresh form
         _state.update { it.copy(
             selectedSource = source,
             editingConnectionId = null,
@@ -388,8 +368,6 @@ class AuthViewModel @Inject constructor(
     }
 
     fun stagePendingLoginCookie(cookie: String) {
-        // Update the volatile cache synchronously so the next interceptor call sees the
-        // value even if the DataStore write is still in flight, then persist async.
         prefs.stagePendingLoginCookie(cookie)
         viewModelScope.launch { prefs.setPendingLoginCookie(cookie) }
     }
@@ -450,7 +428,6 @@ class AuthViewModel @Inject constructor(
 
     fun updateMtlsCertPassword(password: String) {
         _state.update { it.copy(mtlsCertPassword = password, mtlsCertError = null) }
-        // Re-validate if bytes already staged
         val bytes = _state.value.mtlsCertBytes ?: return
         if (bytes.isNotEmpty()) validateStagedMtlsCert(bytes, password)
     }
@@ -491,7 +468,8 @@ class AuthViewModel @Inject constructor(
 
     fun login() {
         val current = _state.value
-        if (current.serverUrl.isBlank() || current.username.isBlank() || current.password.isBlank()) {
+        val requiresCredentials = current.selectedSource != BookSource.OPDS
+        if (current.serverUrl.isBlank() || (requiresCredentials && (current.username.isBlank() || current.password.isBlank()))) {
             _state.update { it.copy(error = "All fields are required") }
             return
         }
@@ -509,7 +487,7 @@ class AuthViewModel @Inject constructor(
 
         viewModelScope.launch {
             _state.update { it.copy(isLoading = true, error = null, serverUrl = normalizedUrl) }
-            val trimmedServerUrl = normalizedUrl.trimEnd('/')
+            val trimmedServerUrl = if (current.selectedSource == BookSource.OPDS) normalizedUrl else normalizedUrl.trimEnd('/')
             val previousSource = prefs.activeBookSource.first()
             val previousConnectionId = prefs.activeConnectionId.first()
             val previousServerUrl = prefs.serverUrl.first()
@@ -522,7 +500,6 @@ class AuthViewModel @Inject constructor(
                     password = current.password,
                 ).map { Unit }
             } else {
-                // Surface source + server first so interceptors pick the right base/token before the network call.
                 prefs.setActiveBookSource(current.selectedSource)
                 prefs.saveServerInfo(trimmedServerUrl, current.username)
                 repository.invalidateListCaches()
@@ -536,7 +513,6 @@ class AuthViewModel @Inject constructor(
             result.onSuccess {
                 val connState = current.copy(serverUrl = normalizedUrl)
                 val connectionId = upsertConnectionForCurrentState(connState)
-                // Store per-connection creds alongside legacy ones
                 storePerConnectionCredentials(connectionId, current.username, current.password)
                 prefs.setActiveConnectionId(connectionId)
                 _state.update {
@@ -570,7 +546,6 @@ class AuthViewModel @Inject constructor(
         var cleaned = url.filter { it >= ' ' }.trim()
         if (cleaned.isEmpty()) return ""
 
-        // Recover pasted URLs containing concatenated or nested schemes.
         val firstProtocolIndex = cleaned.indexOf("://")
         if (firstProtocolIndex != -1) {
             val secondProtocolIndex = cleaned.indexOf("://", firstProtocolIndex + 3)
@@ -587,7 +562,6 @@ class AuthViewModel @Inject constructor(
             }
         }
 
-        // Explicit scheme from the toggle is authoritative; strip any baked-in scheme so the toggle wins.
         return if (scheme != null) {
             val stripped = cleaned.removePrefix("http://").removePrefix("https://")
             "${scheme.prefix}$stripped"
@@ -1000,9 +974,7 @@ class AuthViewModel @Inject constructor(
         val host = uri.host.orEmpty().lowercase()
         val path = uri.path.orEmpty().lowercase()
         val isStorytellerCallback = scheme == "storyteller"
-        // ABS:        audiobookshelf://oauth?…
         val isAbsOauthCallback = scheme == "audiobookshelf" && host == "oauth"
-        // Grimmory:   grimmory://oauth2-callback or legacy booklore://oauth2-callback
         val isGrimmoryOauthCallback = scheme == "grimmory" || scheme == "booklore"
         val isBookOrbitOauthCallback = path.contains("oauth2-callback")
 
@@ -1033,13 +1005,9 @@ class AuthViewModel @Inject constructor(
             .mapNotNull { key -> uri.getQueryParameter(key)?.takeIf { it.isNotBlank() } }
             .firstOrNull()
 
-        // Apply server URL immediately (before the coroutine) so it's in state when
-        // the Storyteller exchange call fires - handles the case where ViewModel state
-        // was reset while AuthBrowserActivity was open (e.g. process recreation).
         if (!callbackServerUrl.isNullOrBlank()) {
             _state.update { it.copy(serverUrl = callbackServerUrl) }
         }
-        // Ensure selectedSource is Storyteller for the callback path even if state reset.
         if (isStorytellerCallback) {
             _state.update { it.copy(selectedSource = BookSource.STORYTELLER) }
         }
@@ -1061,8 +1029,6 @@ class AuthViewModel @Inject constructor(
                     val effectiveToken = resolved?.accessToken ?: token
                     effectiveUrl to effectiveToken
                 } else {
-                    // For Storyteller, prefer the server URL embedded in the callback URI
-                    // (set by AuthBrowserActivity) over the possibly-stale state URL.
                     val stateUrl = _state.value.serverUrl.trim()
                     val serverUrl = callbackServerUrl?.takeIf { it.isNotBlank() } ?: stateUrl
                     serverUrl to token
@@ -1279,10 +1245,6 @@ class AuthViewModel @Inject constructor(
     private fun validateServerUrl(url: String): String? {
         val trimmed = url.trim()
         if (trimmed.isBlank()) return "Server URL is required"
-        // android.net.Uri.parse() is lenient and never throws - it accepts underscores in
-        // hostnames, non-standard ports, and other common internal server naming patterns that
-        // java.net.URI rejects with URISyntaxException, causing a false "Server URL is invalid"
-        // error before any network call is ever attempted.
         val parsed = android.net.Uri.parse(trimmed)
         if (_state.value.selectedSource == BookSource.SMB) {
             return when {
@@ -1310,9 +1272,6 @@ class AuthViewModel @Inject constructor(
         }
     }
 
-    // ─── Plex PIN OAuth ───────────────────────────────────────────────────────
-    // Protocol mechanics live in [PlexPinAuthFlow]; this VM just orchestrates
-    // UI state + token-acquired → connection persistence.
 
     fun startPlexOAuth() {
         viewModelScope.launch {
@@ -1341,21 +1300,8 @@ class AuthViewModel @Inject constructor(
                     return@launch
                 }
 
-                // Persist the plex.tv-issued user token so the Home user picker
-                // can enumerate /api/v2/home/users later — per-connection vault
-                // tokens get overwritten when the user switches, but this one
-                // always lets us list users and switch back to the owner.
                 prefs.setPlexOwnerToken(auth.userToken)
 
-                // Register every Plex server the account has access to as its own
-                // ConnectionRegistry entry (per-user product choice). The first one
-                // becomes the active connection so the rest of the post-login flow
-                // doesn't change.
-                //
-                // No fallback to plex.tv if discovery returned nothing — registering
-                // plex.tv as a "server" then trying GET /library/sections against it
-                // 404s the whole library load. Surface the auth-without-servers case
-                // as an explicit error so the user knows to check their PMS.
                 if (auth.allServers.isEmpty()) {
                     _state.update {
                         it.copy(
@@ -1382,8 +1328,6 @@ class AuthViewModel @Inject constructor(
                     )
                     val connId = upsertConnectionForCurrentState(connState)
                     storePerConnectionCredentials(connId, name, null)
-                    // Each Plex server gets its own server-scoped token in the vault
-                    // so multi-server users can browse them independently.
                     runCatching {
                         vault.put(
                             com.enve.core.auth.CredentialVault.accessTokenKey(connId),
@@ -1399,16 +1343,6 @@ class AuthViewModel @Inject constructor(
                 val activeId = firstConnId
                 val primary = firstServer
                 if (activeId != null && primary != null) {
-                    // ServiceLoginScreen dismisses when ALL of:
-                    //   authState.isConnected == true
-                    //   authState.activeSource == PLEX
-                    //   authState.loginEpoch > baselineEpoch (captured at screen open)
-                    //
-                    // All three flow from prefs writes through the combine() above
-                    // (line ~139). Write them directly here instead of through
-                    // repository.loginWithToken so a future refactor of that helper
-                    // can't accidentally break login dismissal — these calls are
-                    // load-bearing for the UI.
                     prefs.setActiveBookSource(BookSource.PLEX)
                     prefs.saveServerInfo(
                         url = primary.url,
@@ -1443,13 +1377,6 @@ class AuthViewModel @Inject constructor(
         _state.update { it.copy(plexPolling = false, plexPinId = 0L, plexPinCode = "", error = null) }
     }
 
-    // ─── Plex Home users ──────────────────────────────────────────────────
-    // Lists the users on the owner's Plex Home and lets the user switch to
-    // one. The owner token (stored by startPlexOAuth) is the call credential.
-    // After a successful switch, every Plex connection in the registry gets
-    // the new user-scoped token written to its vault entry, since one user
-    // can have access to multiple servers and we want all of them to see the
-    // switched identity.
 
     fun loadPlexHomeUsers() {
         viewModelScope.launch {
@@ -1522,9 +1449,6 @@ class AuthViewModel @Inject constructor(
         _state.update { it.copy(plexHomeUsersError = null) }
     }
 
-    // ─── Jellyfin Quick Connect ─────────────────────────────────────────────
-    // Protocol mechanics live in [JellyfinQuickConnectFlow]; this VM
-    // orchestrates UI state + token-acquired → connection persistence.
     private var jellyfinPollJob: Job? = null
 
     fun startJellyfinQuickConnect() {
@@ -1552,9 +1476,6 @@ class AuthViewModel @Inject constructor(
                 )
             }
 
-            // Pre-flight: friendlier upfront if QC is admin-disabled.
-            // null result means the probe itself failed (network) — fall through
-            // and let Initiate surface the real error.
             if (jellyfinQuickConnectFlow.isEnabled(normalizedUrl) == false) {
                 _state.update {
                     it.copy(
@@ -1735,7 +1656,6 @@ class AuthViewModel @Inject constructor(
         }
     }
 
-    // Returns the deterministic connection ID so callers can store creds against it
     private suspend fun upsertConnectionForCurrentState(state: AuthState): String {
         val normalizedUrl = state.serverUrl.trim().trimEnd('/')
         val username = state.username.ifBlank { "token-user" }
@@ -1749,7 +1669,6 @@ class AuthViewModel @Inject constructor(
             runCatching { libraryCacheRepository.clearForConnection(existingConnectionId) }
         }
 
-        // Persist any staged mTLS cert to the connection's permanent store
         val certBytes = state.mtlsCertBytes
         if (state.mtlsEnabled && certBytes != null && certBytes.isNotEmpty()) {
             runCatching {
@@ -1757,7 +1676,6 @@ class AuthViewModel @Inject constructor(
             }
         }
 
-        // Store service tokens in encrypted vault
         if (state.serviceClientId.isNotBlank()) {
             vault.put(CredentialVault.serviceClientIdKey(connectionId), state.serviceClientId)
         }
@@ -1785,8 +1703,6 @@ class AuthViewModel @Inject constructor(
                 cloudRootPaths = existingConnection?.cloudRootPaths.orEmpty(),
             )
         )
-        // Connection now carries the Cookie via customHeaders; the pre-login staging slot
-        // is no longer needed and would otherwise leak into the next "Connect" flow.
         prefs.clearPendingLoginContext()
 
         if (state.selectedSource == BookSource.KOMGA) {
@@ -1804,8 +1720,6 @@ class AuthViewModel @Inject constructor(
                 }
             }
         }
-        // Kick a background ingest so Library / Browse / Home start populating immediately
-        // instead of forcing the user to pull-to-refresh after every new server.
         runCatching { libraryCacheRepository.ingestConnectionsInBackground(listOf(connectionId)) }
         return connectionId
     }
@@ -1815,7 +1729,6 @@ class AuthViewModel @Inject constructor(
         return "${source.displayName} ($host)"
     }
 
-    // Store creds keyed by connection ID so each connection has its own tokens
     private fun storePerConnectionCredentials(connectionId: String, username: String?, password: String?) {
         if (!username.isNullOrBlank()) {
             vault.put(CredentialVault.usernameKey(connectionId), username)
@@ -1831,11 +1744,6 @@ class AuthViewModel @Inject constructor(
         if (!password.isNullOrBlank()) {
             vault.put(CredentialVault.passwordKey(connectionId), password)
         }
-        // Mirror the just-written kosync credentials (Grimmory.login wrote them keyed by
-        // serverUrl) onto the connection-keyed slot. The serverUrl-keyed slot is shared
-        // across all accounts on the same host, so without this mirror two Grimmory users
-        // on the same server would each see only the other's kosync creds. Sync paths
-        // prefer the connection-keyed slot when ConnectionScope is set.
         val serverUrl = _state.value.serverUrl.trim().trimEnd('/')
         if (serverUrl.isNotBlank()) {
             vault.get(CredentialVault.kosyncUsernameKey(serverUrl))?.let {
@@ -1847,7 +1755,6 @@ class AuthViewModel @Inject constructor(
         }
     }
 
-    // ─── Connection Management ────────────────────────────────────────────────
 
     fun listConnections(): Flow<List<ProviderConnection>> = connectionRegistry.connections
 
@@ -1865,17 +1772,10 @@ class AuthViewModel @Inject constructor(
         viewModelScope.launch {
             connectionRegistry.setEnabled(connectionId, enabled)
             if (!enabled) {
-                // Disabling a connection should immediately stop its books from showing up
-                // in Browse / Home counts. Cache entries get cleared; the next refresh after
-                // re-enabling repopulates them. Same semantics as removeConnection without
-                // touching credentials. Downloaded files on disk are NOT touched; the user
-                // can still play/read them via the Downloads tab.
                 runCatching { libraryCacheRepository.clearForConnection(connectionId) }
                 runCatching { aggregatorRepository.invalidateCaches() }
                 runCatching { aggregatorRepository.clearHomeSnapshotCache() }
             } else {
-                // Re-enable: ingest just this connection so we don't re-fetch every other
-                // server's books.
                 runCatching { libraryCacheRepository.ingestConnectionsInBackground(listOf(connectionId)) }
             }
         }
@@ -1886,11 +1786,9 @@ class AuthViewModel @Inject constructor(
             val connection = connectionRegistry.connections.first()
                 .find { it.id == connectionId } ?: return@launch
 
-            // Update the legacy single-server keys so interceptors/repos just work
             prefs.setActiveBookSource(connection.source)
             prefs.saveServerInfo(connection.serverUrl, connection.username)
 
-            // Restore per-connection tokens to legacy keys
             val accessToken = vault.get(CredentialVault.accessTokenKey(connectionId))
             val refreshToken = vault.get(CredentialVault.refreshTokenKey(connectionId))
             if (!accessToken.isNullOrBlank()) {
@@ -1908,7 +1806,6 @@ class AuthViewModel @Inject constructor(
 
     fun removeConnection(connectionId: String) {
         viewModelScope.launch {
-            // Nuke per-connection creds
             vault.remove(CredentialVault.accessTokenKey(connectionId))
             vault.remove(CredentialVault.refreshTokenKey(connectionId))
             vault.remove(CredentialVault.passwordKey(connectionId))
@@ -1919,10 +1816,6 @@ class AuthViewModel @Inject constructor(
             vault.remove(CredentialVault.kosyncPasswordKeyForConnection(connectionId))
             mtlsManager.clearCert(connectionId)
 
-            // Drop cached books/libraries for this connection so Home/Library don't keep
-            // rendering content from a server the user just deleted. Downloaded books on
-            // disk (OfflineDownloadManager / ComicOfflineService) are intentionally NOT
-            // touched — the user can still read/listen to those locally.
             runCatching { libraryCacheRepository.clearForConnection(connectionId) }
             runCatching { aggregatorRepository.invalidateCaches() }
             runCatching { aggregatorRepository.clearHomeSnapshotCache() }
@@ -1933,18 +1826,12 @@ class AuthViewModel @Inject constructor(
                 prefs.clearActiveConnectionId()
             }
 
-            // Wipe the legacy single-server fields once the registry empties so Settings
-            // stops showing the deleted server's URL.
             if (connectionRegistry.connections.first().isEmpty()) {
                 prefs.clearAuth()
             }
         }
     }
 
-    // Cloudflare Access cookies (CF_Authorization) are short-lived JWTs (default 24h).
-    // After a couple of restarts they'll be expired and every API call returns the IdP
-    // challenge HTML. Decode the JWT exp claim on launch and flag connections whose
-    // cookie is gone - the LibraryConnections row already shows a "Needs sign in" badge.
     private suspend fun flagExpiredCloudflareCookies() {
         val nowSec = System.currentTimeMillis() / 1000L
         val expiryBufferSec = 60L
@@ -1985,9 +1872,6 @@ class AuthViewModel @Inject constructor(
         0L
     }
 
-    // Walks every Komga connection and queries /api/v1/users/me to update isAdmin. Runs in
-    // ConnectionScope per connection so the request hits the right server. Failures (network,
-    // 401, etc.) are silent - admin flag just isn't updated.
     private suspend fun refreshKomgaAdminFlags() {
         val current = connectionRegistry.connections.first()
             .filter { it.source == BookSource.KOMGA && it.enabled }
@@ -2043,9 +1927,6 @@ class AuthViewModel @Inject constructor(
         }
     }
 
-    // Re-stage a fresh CF_Authorization cookie captured from the in-app browser onto an
-    // existing connection. Replaces only the Cookie header so other custom headers (e.g. a
-    // user-added X-Forwarded-Host) are preserved.
     fun restoreCloudflareCookieForConnection(connectionId: String, cookie: String) {
         if (cookie.isBlank()) return
         viewModelScope.launch {

--- a/android/app/src/main/java/com/enve/app/ui/screens/EbookReaderActivity.kt
+++ b/android/app/src/main/java/com/enve/app/ui/screens/EbookReaderActivity.kt
@@ -5,6 +5,7 @@ import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
+import android.graphics.drawable.ColorDrawable
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.os.Bundle
@@ -22,6 +23,7 @@ import android.widget.Toast
 import android.speech.tts.TextToSpeech
 import android.speech.tts.UtteranceProgressListener
 import androidx.activity.compose.BackHandler
+import androidx.activity.SystemBarStyle
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.compose.animation.*
@@ -184,7 +186,7 @@ class EbookReaderActivity : FragmentActivity() {
     private var bookTitle: String = ""
     private var bookAuthor: String = ""
     private var bookLastReadTime: Long = 0L
-    private var requestedReaderEngine: ReaderEngineKind = ReaderEngineKind.READIUM
+    private var requestedReaderEngine by mutableStateOf(ReaderEngineKind.READIUM)
     private var foliateEngine: FoliateReaderEngine? = null
     private var foliateReady = false
     private var foliateFallbackStarted = false
@@ -505,6 +507,29 @@ class EbookReaderActivity : FragmentActivity() {
 
         composeOverlay.setContent {
             val themeState by themeViewModel.themeState.collectAsStateWithLifecycle()
+            val readerState by vm.state.collectAsStateWithLifecycle()
+            val readerTheme = readerState.prefs.theme
+            val readerBackground = if (requestedReaderEngine == ReaderEngineKind.FOLIATE) {
+                when (readerTheme) {
+                    ReaderTheme.LIGHT -> android.graphics.Color.WHITE
+                    ReaderTheme.SEPIA -> 0xFFF4ECD8.toInt()
+                    ReaderTheme.DARK -> 0xFF121212.toInt()
+                    ReaderTheme.OLED -> android.graphics.Color.BLACK
+                }
+            } else {
+                readerState.prefs.toEpubPreferences().theme!!.backgroundColor
+            }
+            DisposableEffect(readerTheme, readerBackground) {
+                window.setBackgroundDrawable(ColorDrawable(readerBackground))
+                epubContainer.setBackgroundColor(readerBackground)
+                val systemBarStyle = if (readerTheme == ReaderTheme.LIGHT || readerTheme == ReaderTheme.SEPIA) {
+                    SystemBarStyle.light(readerBackground, readerBackground)
+                } else {
+                    SystemBarStyle.dark(readerBackground)
+                }
+                enableEdgeToEdge(statusBarStyle = systemBarStyle, navigationBarStyle = systemBarStyle)
+                onDispose { }
+            }
             val uiTextScale by hearthPreferences.uiTextScale.collectAsStateWithLifecycle(initialValue = 1f)
             val readNextEnabled by hearthPreferences.readNextEnabled.collectAsStateWithLifecycle(initialValue = true)
             val readNextPosition by hearthPreferences.readNextPosition.collectAsStateWithLifecycle(
@@ -601,7 +626,7 @@ class EbookReaderActivity : FragmentActivity() {
         }
 
         val hasOfflineSource = comicOfflineStorage.getDownloadedFile(bookId)
-            ?.let { it.exists() && it.length() > 10_240 }
+            ?.let { it.exists() && it.length() > 0L }
             ?: false
         val useReaderNetwork = shouldUseReaderNetwork(
             hasOfflineSource = hasOfflineSource,
@@ -681,6 +706,7 @@ class EbookReaderActivity : FragmentActivity() {
             return
         }
 
+        requestedReaderEngine = ReaderEngineKind.READIUM
         val readium  = (application as EnveApplication).readiumManager
         val customFontResources = ReadiumCustomFontResources(customFonts)
         val readiumOpenStartMs = android.os.SystemClock.elapsedRealtime()
@@ -1294,7 +1320,7 @@ class EbookReaderActivity : FragmentActivity() {
     ): File {
 
         val offlineFile = comicOfflineStorage.getDownloadedFile(bookId)
-        if (offlineFile != null && offlineFile.exists() && offlineFile.length() > 10_240) {
+        if (offlineFile != null && offlineFile.exists() && offlineFile.length() > 0) {
             setStatus("Loading offline ${format.displayName}\u2026")
             validateDownloadedEbookSource(offlineFile, format)
             return offlineFile
@@ -1314,7 +1340,7 @@ class EbookReaderActivity : FragmentActivity() {
         }
         val cached   = File(dir, cachedName)
 
-        if (cached.exists() && cached.length() > 10_240) {
+        if (cached.exists() && cached.length() > 0) {
             if (isZipBackedEbook(format) && !looksLikeZip(cached)) {
                 cached.delete()
             } else {
@@ -1338,7 +1364,7 @@ class EbookReaderActivity : FragmentActivity() {
                 val input = contentResolver.openInputStream(android.net.Uri.parse(downloadUrl))
                     ?: throw Exception("Couldn't open the local file. Was it moved or deleted?")
                 input.use { inp -> FileOutputStream(tmp).use { out -> inp.copyTo(out) } }
-                if (tmp.length() < 1024) { tmp.delete(); throw Exception("File too small") }
+                if (tmp.length() == 0L) { tmp.delete(); throw Exception("File is empty") }
                 validateDownloadedEbookSource(tmp, format)
                 if (cached.exists()) cached.delete()
                 if (!tmp.renameTo(cached)) {
@@ -1385,7 +1411,7 @@ class EbookReaderActivity : FragmentActivity() {
                 tmp.delete()
                 throw Exception("The download stopped early — got ${total / 1024} KB of ${len / 1024} KB.")
             }
-            if (tmp.length() < 1024) { tmp.delete(); throw Exception("File too small") }
+            if (tmp.length() == 0L) { tmp.delete(); throw Exception("File is empty") }
             validateDownloadedEbookSource(tmp, format)
             if (cached.exists()) cached.delete()
             if (!tmp.renameTo(cached)) {
@@ -1760,16 +1786,6 @@ private fun ReaderOverlay(
         onDispose {
             controller?.show(WindowInsetsCompat.Type.statusBars() or WindowInsetsCompat.Type.navigationBars())
             controller?.systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_DEFAULT
-        }
-    }
-
-    DisposableEffect(uiState.prefs.theme) {
-        val window = activity?.window
-        val controller = window?.let { WindowCompat.getInsetsController(it, it.decorView) }
-        val isLightTheme = uiState.prefs.theme == ReaderTheme.LIGHT || uiState.prefs.theme == ReaderTheme.SEPIA
-        controller?.isAppearanceLightStatusBars = isLightTheme
-        onDispose {
-            controller?.isAppearanceLightStatusBars = false
         }
     }
 

--- a/android/app/src/main/java/com/enve/app/ui/screens/ReaderSupport.kt
+++ b/android/app/src/main/java/com/enve/app/ui/screens/ReaderSupport.kt
@@ -68,7 +68,7 @@ internal suspend fun downloadReaderFile(
     val safeName = bookId.replace(Regex("[^a-zA-Z0-9_-]"), "_")
     val cached = File(dir, "$safeName.${format.cacheExtension}")
 
-    if (cached.exists() && cached.length() > 10_240) {
+    if (cached.exists() && cached.length() > 0) {
         onStatus("Loading cached ${format.displayName}…")
         return cached
     }
@@ -82,9 +82,9 @@ internal suspend fun downloadReaderFile(
             val input = contentResolver.openInputStream(android.net.Uri.parse(downloadUrl))
                 ?: throw IllegalStateException("Couldn't open the local file. Was it moved or deleted?")
             input.use { inp -> FileOutputStream(tmp).use { out -> inp.copyTo(out) } }
-            if (tmp.length() < 1024) {
+            if (tmp.length() == 0L) {
                 tmp.delete()
-                throw IllegalStateException("File too small")
+                throw IllegalStateException("File is empty")
             }
             if (cached.exists()) cached.delete()
             if (!tmp.renameTo(cached)) {
@@ -118,9 +118,9 @@ internal suspend fun downloadReaderFile(
             }
         }
 
-        if (tmp.length() < 1024) {
+        if (tmp.length() == 0L) {
             tmp.delete()
-            throw IllegalStateException("File too small")
+            throw IllegalStateException("File is empty")
         }
 
         if (cached.exists()) cached.delete()

--- a/android/app/src/main/java/com/enve/app/viewmodel/ComicReaderViewModel.kt
+++ b/android/app/src/main/java/com/enve/app/viewmodel/ComicReaderViewModel.kt
@@ -422,7 +422,7 @@ class ComicReaderViewModel @Inject constructor(
         }
 
         val offlineFile = comicOfflineService.getLocalFile(bookId)
-        if (offlineFile != null && offlineFile.exists() && offlineFile.length() > 1024) {
+        if (offlineFile != null && offlineFile.exists() && offlineFile.length() > 0L) {
             val pages = try {
                 loadOrExtractComicPages(
                     cacheDir = appContext.cacheDir,

--- a/android/app/src/release/AndroidManifest.xml
+++ b/android/app/src/release/AndroidManifest.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <application>
+        <meta-data
+            android:name="com.google.android.gms.car.application"
+            tools:node="remove" />
+        <meta-data
+            android:name="androidx.car.app.TintableAttributionIcon"
+            tools:node="remove" />
+        <meta-data
+            android:name="com.google.android.gms.car.application.theme"
+            tools:node="remove" />
+    </application>
+</manifest>

--- a/android/audiobookshelf/src/main/java/com/enve/audiobookshelf/AbsProgressNormalization.kt
+++ b/android/audiobookshelf/src/main/java/com/enve/audiobookshelf/AbsProgressNormalization.kt
@@ -1,0 +1,70 @@
+package com.enve.audiobookshelf
+
+import com.enve.audiobookshelf.dto.AbsMediaProgressDto
+import com.enve.core.data.model.AppMediaType
+import com.enve.core.data.model.Book
+
+internal fun applyAbsMediaProgress(base: Book, progress: AbsMediaProgressDto): Book {
+    val durationSec = progress.duration
+        ?.takeIf { it > 0.0 }
+        ?.let { normalizeAbsDurationSeconds(it, base.duration.takeIf { d -> d > 0L }) }
+        ?: base.duration
+    val audioProgress = progress.progress?.coerceIn(0f, 1f) ?: base.readProgress
+    val ebookProgress = progress.ebookProgress?.coerceIn(0f, 1f)
+        ?: base.epubProgress.takeIf { base.mediaType == AppMediaType.EBOOK || base.hasEbook }
+    val currentTimeSec = normalizeAbsCurrentTimeSeconds(
+        rawCurrentTime = progress.currentTime,
+        durationSec = durationSec,
+        progressFraction = progress.progress,
+        fallbackSec = base.currentTime,
+    )
+    val lastReadTime = progress.lastUpdate
+        ?.takeIf { it > 0L }
+        ?.let { if (it < 100_000_000_000L) it * 1000L else it }
+        ?: base.lastReadTime
+
+    return base.copy(
+        duration = durationSec,
+        currentTime = currentTimeSec,
+        readProgress = audioProgress,
+        epubProgress = ebookProgress,
+        epubLocator = progress.ebookLocation
+            ?: base.epubLocator.takeIf { ebookProgress == base.epubProgress },
+        lastReadTime = lastReadTime,
+        isFinished = progress.resolvedIsFinished || (ebookProgress ?: 0f) >= 0.99f,
+        serverReadStatus = null,
+    )
+}
+
+internal fun normalizeAbsDurationSeconds(rawDuration: Double, referenceDurationSec: Long?): Long {
+    if (rawDuration <= 0.0) return 0L
+    val raw = rawDuration.toLong()
+    if (raw <= 0L) return 0L
+    val ref = referenceDurationSec?.takeIf { it > 0L }
+    if (ref != null) {
+        if (raw > ref * 10L) return (raw / 1000L).coerceAtLeast(1L)
+        return raw
+    }
+    return if (raw > 1_000_000L) (raw / 1000L).coerceAtLeast(1L) else raw
+}
+
+internal fun normalizeAbsCurrentTimeSeconds(
+    rawCurrentTime: Double?,
+    durationSec: Long,
+    progressFraction: Float?,
+    fallbackSec: Long?,
+): Long {
+    val computedFromProgress = progressFraction
+        ?.coerceIn(0f, 1f)
+        ?.let { pct -> if (durationSec > 0L) (durationSec * pct).toLong() else null }
+    val raw = rawCurrentTime?.takeIf { it >= 0.0 }?.toLong()
+    val normalized = when {
+        raw == null -> null
+        durationSec > 0L && raw > durationSec * 10L -> raw / 1000L
+        raw > 10_000_000L -> raw / 1000L
+        else -> raw
+    }
+    val candidate = normalized?.takeIf { it > 0L }
+        ?: computedFromProgress ?: normalized ?: fallbackSec ?: 0L
+    return if (durationSec > 0L) candidate.coerceIn(0L, durationSec) else candidate.coerceAtLeast(0L)
+}

--- a/android/audiobookshelf/src/main/java/com/enve/audiobookshelf/AudiobookshelfProgressSyncStrategy.kt
+++ b/android/audiobookshelf/src/main/java/com/enve/audiobookshelf/AudiobookshelfProgressSyncStrategy.kt
@@ -3,7 +3,7 @@ package com.enve.audiobookshelf
 import com.enve.core.data.local.BookCacheDao
 import com.enve.core.data.local.ConnectionRegistry
 import com.enve.core.data.local.toCachedBook
-import com.enve.core.data.model.Book
+import com.enve.core.data.local.toBook
 import com.enve.core.data.model.BookSource
 import com.enve.core.data.remote.ConnectionScope
 import com.enve.core.data.sync.ProviderSyncResult
@@ -31,16 +31,20 @@ class AudiobookshelfProgressSyncStrategy @Inject constructor(
         if (!force && lastSyncAtMs?.let { now - it < MIN_SYNC_INTERVAL_MS } == true) {
             return ProviderSyncResult.ZERO
         }
-        lastSyncAtMs = now
 
         val connections = connectionRegistry.connections.first()
             .filter { it.enabled && it.source == BookSource.AUDIOBOOKSHELF }
         var pulled = 0
+        var failed = false
 
         for (connection in connections) {
             val books = try {
                 withContext(ConnectionScope.asContextElement(connection.id)) {
-                    repository.getBooksInProgress().getOrThrow()
+                    val localBooks = bookCacheDao.getBySourceAndConnection(
+                        BookSource.AUDIOBOOKSHELF.name, connection.id,
+                    ).map { it.toBook() }
+                    val updated = repository.getProgressForBooks(localBooks)
+                    val discovered = repository.getBooksInProgress(allowCachedFallback = false).getOrThrow()
                         .map { book ->
                             val rawLibraryId = book.libraryId
                                 ?.substringAfter("::", missingDelimiterValue = book.libraryId.orEmpty())
@@ -50,39 +54,41 @@ class AudiobookshelfProgressSyncStrategy @Inject constructor(
                                 libraryId = rawLibraryId?.let { "${connection.id}::$it" },
                             )
                         }
+                    (updated + discovered).groupBy { it.uniqueKey }
+                        .values.map { entries -> entries.maxBy { it.lastReadTime } }
                 }
             } catch (e: CancellationException) {
                 throw e
             } catch (_: Exception) {
+                failed = true
                 continue
             }
 
-            if (books.isNotEmpty()) {
-                val newBooks = mutableListOf<Book>()
-                for (book in books) {
-                    val existing = bookCacheDao.getByCacheKey(book.uniqueKey)
-                    if (existing == null) {
-                        newBooks += book
-                    } else {
-                        val progress = maxOf(book.readProgress, book.epubProgress ?: 0f)
-                        bookCacheDao.updateUnifiedProgress(
-                            bookId = book.id,
-                            connectionId = connection.id,
-                            progress = progress,
-                            currentTimeSec = book.currentTime.takeIf { it > 0L } ?: -1L,
-                            locatorJson = book.epubLocator,
-                            nowMs = book.lastReadTime.takeIf { it > 0L } ?: now,
-                        )
-                    }
+            for (book in books) {
+                if (bookCacheDao.insertIfAbsent(book.toCachedBook(now)) != -1L) {
+                    pulled++
+                } else {
+                    pulled += bookCacheDao.applyRemoteProgress(
+                        cacheKey = book.uniqueKey,
+                        source = BookSource.AUDIOBOOKSHELF.name,
+                        progress = book.readProgress,
+                        ebookProgress = book.epubProgress,
+                        currentTimeSec = book.currentTime,
+                        locatorJson = book.epubLocator,
+                        finished = book.isFinished,
+                        readStatus = book.serverReadStatus,
+                        updatedAt = book.lastReadTime,
+                    )
                 }
-                if (newBooks.isNotEmpty()) {
-                    bookCacheDao.upsert(newBooks.map { it.toCachedBook(now) })
-                }
-                pulled += books.size
             }
         }
 
-        return ProviderSyncResult(pulled = pulled, pushed = 0)
+        if (!failed) lastSyncAtMs = now
+        return ProviderSyncResult(
+            pulled = pulled,
+            pushed = 0,
+            failedBackends = if (failed) listOf(displayName) else emptyList(),
+        )
     }
 
     private companion object {

--- a/android/audiobookshelf/src/main/java/com/enve/audiobookshelf/AudiobookshelfRepository.kt
+++ b/android/audiobookshelf/src/main/java/com/enve/audiobookshelf/AudiobookshelfRepository.kt
@@ -481,7 +481,7 @@ class AudiobookshelfRepository @Inject constructor(
         val mediaType = resolveAbsMediaType(dto)
         val progressFraction = (dto.mediaProgress?.progress ?: 0f).coerceIn(0f, 1f)
         val readStatus = when {
-            dto.mediaProgress?.isFinished == true -> com.enve.core.data.model.ReadStatus.COMPLETED
+            dto.mediaProgress?.resolvedIsFinished == true -> com.enve.core.data.model.ReadStatus.COMPLETED
             progressFraction > 0f -> com.enve.core.data.model.ReadStatus.IN_PROGRESS
             else -> com.enve.core.data.model.ReadStatus.UNREAD
         }
@@ -606,7 +606,7 @@ class AudiobookshelfRepository @Inject constructor(
             audioTracks = tracks,
             hasAudio = hasAbsAudio(media),
             hasEbook = hasAbsEbook(media),
-            isFinished = progress?.isFinished == true || progressFraction >= 0.99f,
+            isFinished = progress?.resolvedIsFinished == true,
             primaryFileType = primaryFileType,
         )
     }
@@ -652,33 +652,7 @@ class AudiobookshelfRepository @Inject constructor(
         val base = mapAbsItemToBook(dto, libraryId, serverUrl, fetchDetail = fetchDetail) ?: return null
         val progress = dto.mediaProgress
         if (progress == null) return base
-
-        val durationSec = progress.duration
-            ?.takeIf { it > 0.0 }
-            ?.let { normalizeAbsDurationSeconds(it, base.duration.takeIf { d -> d > 0L }) }
-            ?: base.duration
-        val audioProgress = progress.progress?.coerceIn(0f, 1f) ?: base.readProgress
-        val ebookProgress = progress.ebookProgress?.coerceIn(0f, 1f) ?: base.epubProgress
-        val currentTimeSec = normalizeAbsCurrentTimeSeconds(
-            rawCurrentTime = progress.currentTime,
-            durationSec = durationSec,
-            progressFraction = audioProgress,
-            fallbackSec = base.currentTime,
-        )
-        val lastReadTime = progress.lastUpdate
-            ?.takeIf { it > 0L }
-            ?.let { if (it < 100_000_000_000L) it * 1000L else it }
-            ?: base.lastReadTime
-
-        return base.copy(
-            duration = durationSec,
-            currentTime = currentTimeSec,
-            readProgress = audioProgress,
-            epubProgress = ebookProgress,
-            epubLocator = progress.ebookLocation ?: base.epubLocator,
-            lastReadTime = lastReadTime,
-            isFinished = progress.isFinished == true || audioProgress >= 0.99f || (ebookProgress ?: 0f) >= 0.99f,
-        )
+        return applyAbsMediaProgress(base, progress)
     }
 
     private fun mapAudioFileToTrack(itemId: String, file: AbsAudioFileDto, serverUrl: String): AudioTrack? {
@@ -822,46 +796,6 @@ class AudiobookshelfRepository @Inject constructor(
         }
     }
 
-    private fun normalizeAbsDurationSeconds(rawDuration: Double, referenceDurationSec: Long?): Long {
-        if (rawDuration <= 0.0) return 0L
-        val raw = rawDuration.toLong()
-        if (raw <= 0L) return 0L
-        val ref = referenceDurationSec?.takeIf { it > 0L }
-        if (ref != null) {
-            if (raw > ref * 10L) return (raw / 1000L).coerceAtLeast(1L)
-            if (raw * 10L < ref) return raw.coerceAtLeast(1L)
-            return raw.coerceAtLeast(1L)
-        }
-        return if (raw > 1_000_000L) (raw / 1000L).coerceAtLeast(1L) else raw
-    }
-
-    private fun normalizeAbsCurrentTimeSeconds(
-        rawCurrentTime: Double?,
-        durationSec: Long,
-        progressFraction: Float?,
-        fallbackSec: Long?,
-    ): Long {
-        val computedFromProgress = progressFraction
-            ?.coerceIn(0f, 1f)
-            ?.let { pct -> if (durationSec > 0L) (durationSec * pct).toLong() else null }
-
-        val raw = rawCurrentTime?.takeIf { it > 0.0 }?.toLong()
-        val normalized = when {
-            raw == null -> null
-            durationSec > 0L && raw > durationSec * 10L -> raw / 1000L
-            raw > 10_000_000L -> raw / 1000L
-            else -> raw
-        }
-
-        val candidate = when {
-            normalized != null && normalized > 0L -> normalized
-            computedFromProgress != null && computedFromProgress > 0L -> computedFromProgress
-            else -> fallbackSec
-        } ?: 0L
-
-        return if (durationSec > 0L) candidate.coerceIn(0L, durationSec) else candidate.coerceAtLeast(0L)
-    }
-
     suspend fun getAudioTracks(book: Book): Result<List<AudioTrack>> {
         return startPlaybackSession(book).mapCatching { session ->
             session.audioTracks.ifEmpty {
@@ -956,6 +890,16 @@ class AudiobookshelfRepository @Inject constructor(
         Result.failure(e)
     }
 
+    suspend fun getProgressForBooks(books: List<Book>): List<Book> {
+        val response = api.getMe()
+        check(response.isSuccessful) { "ABS user progress failed: HTTP ${response.code()}" }
+        val progress = checkNotNull(response.body()) { "ABS user progress returned an empty body" }
+            .mediaProgress.filter { it.episodeId == null }
+            .groupBy { it.libraryItemId }
+            .mapValues { (_, entries) -> entries.maxBy { it.lastUpdate ?: 0L } }
+        return books.mapNotNull { book -> progress[book.id]?.let { applyAbsMediaProgress(book, it) } }
+    }
+
     suspend fun createBookmark(
         itemId: String,
         request: com.enve.audiobookshelf.dto.AbsBookmarkRequest,
@@ -1000,7 +944,7 @@ class AudiobookshelfRepository @Inject constructor(
         }
     }
 
-    suspend fun getBooksInProgress(): Result<List<Book>> {
+    suspend fun getBooksInProgress(allowCachedFallback: Boolean = true): Result<List<Book>> {
         return try {
             val serverUrl = scopedServerUrlAndToken().first
             val normalizedUrl = serverUrl.trimEnd('/')
@@ -1035,6 +979,7 @@ class AudiobookshelfRepository @Inject constructor(
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
+            if (!allowCachedFallback) return Result.failure(e)
             val cached = runCatching {
                 val serverUrl = scopedServerUrlAndToken().first.trimEnd('/')
                 loadLaneFromDisk(serverUrl, "in-progress")

--- a/android/audiobookshelf/src/main/java/com/enve/audiobookshelf/dto/AbsDto.kt
+++ b/android/audiobookshelf/src/main/java/com/enve/audiobookshelf/dto/AbsDto.kt
@@ -134,14 +134,24 @@ data class AbsSeriesPayload(
 data class AbsMediaProgressDto(
     val id: String? = null,
     val libraryItemId: String? = null,
+    val episodeId: String? = null,
     val duration: Double? = null,
     val progress: Float? = null,
     val currentTime: Double? = null,
     val isFinished: Boolean? = null,
+    val finishedAt: Long? = null,
     val lastUpdate: Long? = null,
     val ebookLocation: String? = null,
     val ebookProgress: Float? = null,
-)
+) {
+    val resolvedIsFinished: Boolean
+        get() {
+            if (isFinished == true || finishedAt != null || (progress ?: 0f) >= 0.99f) return true
+            val total = duration ?: return false
+            val position = currentTime ?: return false
+            return total > 0.0 && position >= total * 0.99
+        }
+}
 
 @Serializable
 data class AbsChaptersResponse(

--- a/android/audiobookshelf/src/test/java/com/enve/audiobookshelf/AbsMediaProgressMergeTest.kt
+++ b/android/audiobookshelf/src/test/java/com/enve/audiobookshelf/AbsMediaProgressMergeTest.kt
@@ -3,7 +3,9 @@ package com.enve.audiobookshelf
 import com.enve.audiobookshelf.dto.AbsLibraryItemDto
 import com.enve.audiobookshelf.dto.AbsMediaProgressDto
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class AbsMediaProgressMergeTest {
@@ -41,5 +43,29 @@ class AbsMediaProgressMergeTest {
         val merged = mergeAbsMediaProgress(listOf(item), emptyList())
 
         assertEquals(inline, merged.single().mediaProgress)
+    }
+
+    @Test
+    fun resolvesEveryAudiobookshelfCompletionSignal() {
+        assertTrue(AbsMediaProgressDto(isFinished = true).resolvedIsFinished)
+        assertTrue(AbsMediaProgressDto(finishedAt = 1L).resolvedIsFinished)
+        assertTrue(AbsMediaProgressDto(progress = 0.99f).resolvedIsFinished)
+        assertTrue(
+            AbsMediaProgressDto(
+                duration = 1_000.0,
+                currentTime = 990.0,
+            ).resolvedIsFinished,
+        )
+    }
+
+    @Test
+    fun doesNotResolveIncompleteProgressAsFinished() {
+        assertFalse(
+            AbsMediaProgressDto(
+                duration = 1_000.0,
+                currentTime = 500.0,
+                progress = 0.5f,
+            ).resolvedIsFinished,
+        )
     }
 }

--- a/android/audiobookshelf/src/test/java/com/enve/audiobookshelf/AbsProgressNormalizationTest.kt
+++ b/android/audiobookshelf/src/test/java/com/enve/audiobookshelf/AbsProgressNormalizationTest.kt
@@ -1,0 +1,49 @@
+package com.enve.audiobookshelf
+
+import com.enve.audiobookshelf.dto.AbsMediaProgressDto
+import com.enve.core.data.model.Book
+import com.enve.core.data.model.AppMediaType
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AbsProgressNormalizationTest {
+    @Test
+    fun resettingPreviouslyUnifiedAudioProgressClearsFinishedState() {
+        val book = Book(id = "audio", title = "Audio", duration = 1000L,
+            currentTime = 1000L, isFinished = true, readProgress = 1f, epubProgress = 1f)
+        val updated = applyAbsMediaProgress(book, AbsMediaProgressDto(
+            currentTime = 0.0, progress = 0f, isFinished = false, lastUpdate = 1_800_000_000_000L,
+        ))
+        assertEquals(0L, updated.currentTime)
+        assertEquals(false, updated.isFinished)
+        assertEquals(null, updated.epubProgress)
+    }
+
+    @Test
+    fun ebookResetClearsOldLocator() {
+        val book = Book(id = "ebook", title = "Ebook", mediaType = AppMediaType.EBOOK,
+            epubProgress = 0.5f, epubLocator = "old-locator")
+        val updated = applyAbsMediaProgress(book, AbsMediaProgressDto(ebookProgress = 0f))
+        assertEquals(0f, updated.epubProgress)
+        assertEquals(null, updated.epubLocator)
+    }
+
+    @Test
+    fun explicitResetDoesNotRestoreCachedPosition() {
+        assertEquals(0L, normalizeAbsCurrentTimeSeconds(0.0, 1000L, 0f, 900L))
+        assertEquals(0L, normalizeAbsCurrentTimeSeconds(null, 1000L, 0f, 900L))
+        assertEquals(0L, normalizeAbsCurrentTimeSeconds(0.0, 0L, null, 900L))
+    }
+
+    @Test
+    fun missingProgressPreservesCachedPosition() {
+        assertEquals(900L, normalizeAbsCurrentTimeSeconds(null, 1000L, null, 900L))
+    }
+
+    @Test
+    fun normalizesLegacyMillisecondsAndClampsToDuration() {
+        assertEquals(120L, normalizeAbsCurrentTimeSeconds(120000.0, 1000L, 0.12f, 0L))
+        assertEquals(500L, normalizeAbsCurrentTimeSeconds(0.0, 1000L, 0.5f, 900L))
+        assertEquals(1000L, normalizeAbsCurrentTimeSeconds(1100.0, 1000L, null, null))
+    }
+}

--- a/android/bookorbit/src/main/java/com/enve/bookorbit/BookOrbitDiscoveryRepository.kt
+++ b/android/bookorbit/src/main/java/com/enve/bookorbit/BookOrbitDiscoveryRepository.kt
@@ -13,7 +13,7 @@ data class BookOrbitRelatedBook(
     val title: String,
     val authors: List<String>,
     val coverUrl: String?,
-    val seriesIndex: Double?,
+    val seriesIndex: String?,
     val isAudiobook: Boolean,
 )
 

--- a/android/bookorbit/src/main/java/com/enve/bookorbit/BookOrbitRepository.kt
+++ b/android/bookorbit/src/main/java/com/enve/bookorbit/BookOrbitRepository.kt
@@ -674,7 +674,7 @@ class BookOrbitRepository @Inject constructor(
             isFinished = status == ReadStatus.COMPLETED,
             serverReadStatus = readStatus?.status?.uppercase(),
             seriesName = seriesName,
-            seriesNumber = seriesIndex?.let(::sequenceString),
+            seriesNumber = seriesIndex,
             publisher = publisher,
             publishedDate = publishedYear?.toString(),
             isbn13 = isbn13,
@@ -721,7 +721,7 @@ class BookOrbitRepository @Inject constructor(
             isFinished = status == ReadStatus.COMPLETED,
             serverReadStatus = readStatus?.status?.uppercase(),
             seriesName = seriesName,
-            seriesNumber = seriesIndex?.let(::sequenceString),
+            seriesNumber = seriesIndex,
             publisher = publisher,
             publishedDate = publishedYear?.toString(),
             isbn13 = isbn13,
@@ -971,9 +971,6 @@ class BookOrbitRepository @Inject constructor(
 
     private fun isAudio(format: String?): Boolean =
         format?.lowercase() in setOf("m4b", "mp3", "m4a", "opus", "ogg", "flac", "wav", "aac", "aax")
-
-    private fun sequenceString(value: Double): String =
-        if (value % 1.0 == 0.0) value.toInt().toString() else value.toString()
 
     private fun parseDateMillis(raw: String?): Long? {
         if (raw.isNullOrBlank()) return null

--- a/android/bookorbit/src/main/java/com/enve/bookorbit/dto/BookOrbitDiscoveryDto.kt
+++ b/android/bookorbit/src/main/java/com/enve/bookorbit/dto/BookOrbitDiscoveryDto.kt
@@ -7,7 +7,8 @@ data class BookOrbitRecommendationDto(
     val id: Int,
     val title: String? = null,
     val updatedAt: String? = null,
-    val seriesIndex: Double? = null,
+    @Serializable(with = BookOrbitSeriesIndexSerializer::class)
+    val seriesIndex: String? = null,
     val hasCover: Boolean = false,
     val authors: List<String> = emptyList(),
     val isAudiobook: Boolean = false,

--- a/android/bookorbit/src/main/java/com/enve/bookorbit/dto/BookOrbitDto.kt
+++ b/android/bookorbit/src/main/java/com/enve/bookorbit/dto/BookOrbitDto.kt
@@ -1,6 +1,36 @@
 package com.enve.bookorbit.dto
 
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.jsonPrimitive
+
+object BookOrbitSeriesIndexSerializer : KSerializer<String?> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("BookOrbitSeriesIndex", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): String? {
+        val json = decoder as? JsonDecoder ?: return decoder.decodeString()
+        val value = json.decodeJsonElement()
+        if (value is JsonNull) return null
+        val primitive = value.jsonPrimitive
+        return if (primitive.isString) primitive.content else primitive.content.toDoubleOrNull()?.let { number ->
+            if (number % 1.0 == 0.0) number.toLong().toString() else number.toString()
+        } ?: primitive.content
+    }
+
+    @OptIn(ExperimentalSerializationApi::class)
+    override fun serialize(encoder: Encoder, value: String?) {
+        if (value == null) encoder.encodeNull() else encoder.encodeString(value)
+    }
+}
 
 @Serializable
 data class BookOrbitLoginRequest(
@@ -122,7 +152,8 @@ data class BookOrbitBookCardDto(
     val authors: List<String> = emptyList(),
     val narrators: List<String> = emptyList(),
     val seriesName: String? = null,
-    val seriesIndex: Double? = null,
+    @Serializable(with = BookOrbitSeriesIndexSerializer::class)
+    val seriesIndex: String? = null,
     val publishedYear: Int? = null,
     val language: String? = null,
     val genres: List<String> = emptyList(),
@@ -179,7 +210,8 @@ data class BookOrbitBookDetailDto(
     val pageCount: Int? = null,
     val language: String? = null,
     val seriesName: String? = null,
-    val seriesIndex: Double? = null,
+    @Serializable(with = BookOrbitSeriesIndexSerializer::class)
+    val seriesIndex: String? = null,
     val authors: List<BookOrbitAuthorDto> = emptyList(),
     val genres: List<String> = emptyList(),
     val tags: List<String> = emptyList(),

--- a/android/bookorbit/src/test/java/com/enve/bookorbit/BookOrbitServerFeatureDtoTest.kt
+++ b/android/bookorbit/src/test/java/com/enve/bookorbit/BookOrbitServerFeatureDtoTest.kt
@@ -2,6 +2,8 @@ package com.enve.bookorbit
 
 import com.enve.bookorbit.dto.BookOrbitAchievementCatalogueDto
 import com.enve.bookorbit.dto.BookOrbitAnnotationHubPageDto
+import com.enve.bookorbit.dto.BookOrbitBookDetailDto
+import com.enve.bookorbit.dto.BookOrbitBooksPageDto
 import com.enve.bookorbit.dto.BookOrbitProgressFunnelComparisonDto
 import com.enve.bookorbit.dto.BookOrbitReadingSessionsPageDto
 import com.enve.bookorbit.dto.BookOrbitRecommendationDto
@@ -80,14 +82,33 @@ class BookOrbitServerFeatureDtoTest {
             """{"days":30,"current":{"started":10,"reached25":8,"reached50":5,"reached75":3,"completed":2},"previous":null}""",
         )
         val recommendation = json.decodeFromString<BookOrbitRecommendationDto>(
-            """{"id":4,"title":"Next","coverAspectRatio":"2:3","updatedAt":null,"seriesIndex":2.0,"hasCover":true,"authors":["Ada"],"isAudiobook":false}""",
+            """{"id":4,"title":"Next","coverAspectRatio":"2.0","updatedAt":null,"seriesIndex":"1–3","hasCover":true,"authors":["Ada"],"isAudiobook":false}""",
         )
 
         assertEquals(900L, distribution.totalSeconds)
         assertEquals("kobo", distribution.slices[1].bucket)
         assertEquals(2, funnel.current.completed)
         assertNull(funnel.previous)
-        assertEquals(2.0, recommendation.seriesIndex!!, 0.0)
+        assertEquals("1–3", recommendation.seriesIndex)
         assertTrue(recommendation.hasCover)
+    }
+
+    @Test
+    fun decodesTextAndNumericSeriesIndexes() {
+        val page = json.decodeFromString<BookOrbitBooksPageDto>(
+            """{"items":[
+              {"id":1,"seriesIndex":"1–3"},
+              {"id":2,"seriesIndex":"0.50"},
+              {"id":3,"seriesIndex":2.0},
+              {"id":4,"seriesIndex":2.5},
+              {"id":5,"seriesIndex":null}
+            ]}""".trimIndent(),
+        )
+        val detail = json.decodeFromString<BookOrbitBookDetailDto>(
+            """{"id":6,"seriesIndex":"2"}""",
+        )
+
+        assertEquals(listOf("1–3", "0.50", "2", "2.5", null), page.items.map { it.seriesIndex })
+        assertEquals("2", detail.seriesIndex)
     }
 }

--- a/android/core/src/main/java/com/enve/core/data/local/CachedBook.kt
+++ b/android/core/src/main/java/com/enve/core/data/local/CachedBook.kt
@@ -73,6 +73,43 @@ interface BookCacheDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsert(books: List<CachedBook>)
 
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertIfAbsent(book: CachedBook): Long
+
+    @Query("""
+        UPDATE book_cache
+        SET readProgress = :progress,
+            epubProgress = :ebookProgress,
+            currentTime = :currentTimeSec,
+            epubLocator = :locatorJson,
+            isFinished = :finished,
+            serverReadStatus = :readStatus,
+            lastReadTime = :updatedAt,
+            inProgress = CASE
+                WHEN :finished = 0 AND hideFromContinue = 0
+                    AND (:progress > 0.001 OR :ebookProgress > 0.001 OR :currentTimeSec > 0)
+                THEN 1 ELSE 0
+            END
+        WHERE cacheKey = :cacheKey AND source = :source
+            AND :updatedAt > lastReadTime
+            AND NOT EXISTS (
+                SELECT 1 FROM pending_progress_push
+                WHERE bookId = book_cache.id AND source = book_cache.source
+                    AND connectionKey = COALESCE(book_cache.connectionId, '')
+            )
+    """)
+    suspend fun applyRemoteProgress(
+        cacheKey: String,
+        source: String,
+        progress: Float,
+        ebookProgress: Float?,
+        currentTimeSec: Long,
+        locatorJson: String?,
+        finished: Boolean,
+        readStatus: String?,
+        updatedAt: Long,
+    ): Int
+
     @Query("UPDATE book_cache SET epubLocator = :locatorJson, epubProgress = :progress WHERE id = :bookId AND (connectionId = :connectionId OR (:connectionId IS NULL AND connectionId IS NULL))")
     suspend fun updateEpubProgress(bookId: String, connectionId: String?, locatorJson: String?, progress: Float)
 
@@ -674,6 +711,22 @@ interface BookCacheDao {
         LIMIT :limit
     """)
     suspend fun getRecentlyAddedAudiobooks(limit: Int): List<CachedBook>
+
+    @Query("""
+        SELECT * FROM book_cache
+        WHERE mediaType = 'AUDIOBOOK'
+        ORDER BY title COLLATE NOCASE ASC
+        LIMIT :limit
+    """)
+    suspend fun getAudiobooksForCar(limit: Int): List<CachedBook>
+
+    @Query("""
+        SELECT * FROM book_cache
+        WHERE mediaType = 'AUDIOBOOK' AND isDownloaded = 1
+        ORDER BY lastReadTime DESC, addedOn DESC
+        LIMIT :limit
+    """)
+    suspend fun getDownloadedAudiobooksForCar(limit: Int): List<CachedBook>
 }
 
 data class BrowseGroupRow(val name: String, val count: Int)

--- a/android/core/src/main/java/com/enve/core/data/remote/auth/AuthInterceptor.kt
+++ b/android/core/src/main/java/com/enve/core/data/remote/auth/AuthInterceptor.kt
@@ -11,7 +11,6 @@ import com.enve.core.data.remote.TokenRefreshStrategy
 import com.enve.core.data.local.PreferencesManager
 import com.enve.core.data.model.BookSource
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.Interceptor
@@ -29,14 +28,9 @@ class AuthInterceptor @Inject constructor(
     private val authHeaderStrategies: Map<BookSource, @JvmSuppressWildcards AuthHeaderStrategy>,
     private val bearerAuthHeaderStrategy: BearerAuthHeaderStrategy,
     private val tokenRefreshStrategies: Map<BookSource, @JvmSuppressWildcards TokenRefreshStrategy>,
+    private val tokenRefreshCoordinator: TokenRefreshCoordinator,
 ) : Interceptor {
 
-    private val proactiveMutex = Mutex()
-
-    // Cache the decoded JWT exp claim so we don't Base64-decode + JSON-parse on every
-    // single request. Tokens are immutable strings; once decoded, the answer is stable
-    // for the lifetime of that token. Bounded so a long-running session that cycles
-    // through many refreshed tokens doesn't accumulate forever - 32 is plenty.
     private val jwtExpCache: MutableMap<String, Long> = java.util.Collections.synchronizedMap(
         object : LinkedHashMap<String, Long>(32, 0.75f, true) {
             override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, Long>?): Boolean = size > 32
@@ -58,9 +52,6 @@ class AuthInterceptor @Inject constructor(
             return url.host.equals(originalHost, ignoreCase = true) && url.port == originalPort
         }
 
-        // Public/auth endpoints skip the bearer/basic injection but STILL need the CF
-        // Access cookie + per-connection custom headers - otherwise Cloudflare redirects
-        // the login POST to the IdP and the server returns HTML instead of JSON.
         val stagedLoginHeaders = preferencesManager.getPendingLoginHeadersSync()
         val hasStagedLoginContext = stagedLoginHeaders.isNotEmpty()
         if (
@@ -97,14 +88,6 @@ class AuthInterceptor @Inject constructor(
             return chain.proceed(withHeaders)
         }
 
-        // When ConnectionScope is set, the caller has *explicitly* declared which
-        // connection this request belongs to (e.g. fan-out in LibraryListResolver,
-        // per-connection paged fetches). Prefer it over the "active" connection -
-        // otherwise, when two accounts share the same host:port (two Grimmory users
-        // on the same server), every fan-out call would route to the active token,
-        // returning the active user's data for every connection's call. That bug
-        // showed up as books appearing twice and the other account's libraries
-        // missing from the picker.
         val scopedRegistered = scopedConnectionId
             ?.let { id -> connections.find { it.id == id } }
             ?.takeIf { matchesHostPort(it.serverUrl) }
@@ -148,7 +131,7 @@ class AuthInterceptor @Inject constructor(
         val tokenRefreshStrategy = tokenRefreshStrategies[source]
         if (tokenRefreshStrategy != null && token != null && isJwtExpiringSoon(token, bufferSeconds = 60)) {
             val refreshed = runBlocking {
-                proactiveMutex.withLock {
+                tokenRefreshCoordinator.mutex.withLock {
                     val latest = connectionId?.let { vault.get(CredentialVault.accessTokenKey(it)) } ?: preferencesManager.getAccessTokenSync()
                     if (latest != null && !isJwtExpiringSoon(latest, bufferSeconds = 60)) {
                         latest
@@ -226,7 +209,6 @@ class AuthInterceptor @Inject constructor(
     private fun isJwtExpiringSoon(token: String, bufferSeconds: Long): Boolean {
         val exp = jwtExpCache[token] ?: run {
             val decoded = decodeJwtExp(token)
-            // Sentinel 0 marks "couldn't decode" so we don't retry-decode on every request.
             jwtExpCache[token] = decoded
             decoded
         }

--- a/android/core/src/main/java/com/enve/core/data/remote/auth/TokenRefreshAuthenticator.kt
+++ b/android/core/src/main/java/com/enve/core/data/remote/auth/TokenRefreshAuthenticator.kt
@@ -9,7 +9,6 @@ import com.enve.core.data.remote.TokenRefreshStrategy
 import com.enve.core.data.local.PreferencesManager
 import com.enve.core.data.model.BookSource
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import okhttp3.Request
 import okhttp3.Response
@@ -24,13 +23,11 @@ class TokenRefreshAuthenticator @Inject constructor(
     private val vault: CredentialVault,
     private val connectionRegistry: ConnectionRegistry,
     private val tokenRefreshStrategies: Map<BookSource, @JvmSuppressWildcards TokenRefreshStrategy>,
+    private val tokenRefreshCoordinator: TokenRefreshCoordinator,
 ) : Authenticator {
-
-    private val refreshMutex = Mutex()
 
     override fun authenticate(route: Route?, response: Response): Request? {
         val path = response.request.url.encodedPath
-        // Never retry auth / login endpoints to prevent loops
         if (path.contains("auth/login") || path.contains("auth/refresh")) return null
         if (response.request.header("X-Retry-Auth") != null) return null
 
@@ -48,7 +45,7 @@ class TokenRefreshAuthenticator @Inject constructor(
         if (serverUrl.isNullOrBlank()) return null
 
         return runBlocking {
-            refreshMutex.withLock {
+            tokenRefreshCoordinator.mutex.withLock {
                 val currentToken = activeConnectionId?.let { vault.get(CredentialVault.accessTokenKey(it)) }
                     ?: preferencesManager.getAccessTokenSync()
                 val requestToken = response.request.header("Authorization")

--- a/android/core/src/main/java/com/enve/core/data/remote/auth/TokenRefreshCoordinator.kt
+++ b/android/core/src/main/java/com/enve/core/data/remote/auth/TokenRefreshCoordinator.kt
@@ -1,0 +1,10 @@
+package com.enve.core.data.remote.auth
+
+import kotlinx.coroutines.sync.Mutex
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class TokenRefreshCoordinator @Inject constructor() {
+    val mutex = Mutex()
+}

--- a/android/core/src/main/java/com/enve/core/data/sync/ProviderSyncStrategy.kt
+++ b/android/core/src/main/java/com/enve/core/data/sync/ProviderSyncStrategy.kt
@@ -3,6 +3,7 @@ package com.enve.core.data.sync
 data class ProviderSyncResult(
     val pulled: Int,
     val pushed: Int,
+    val failedBackends: List<String> = emptyList(),
 ) {
     companion object {
         val ZERO = ProviderSyncResult(pulled = 0, pushed = 0)

--- a/android/engine/src/main/java/com/enve/app/data/librarian/EbookContextService.kt
+++ b/android/engine/src/main/java/com/enve/app/data/librarian/EbookContextService.kt
@@ -122,14 +122,14 @@ class EbookContextService @Inject constructor(
         val dir = File(context.cacheDir, "librarian-ebook-sources").also { it.mkdirs() }
         val safeName = fileSafeName(book.stableId)
         val cached = File(dir, "$safeName.${book.sourceFormat.extension}")
-        if (cached.exists() && cached.length() > 10_240L) return@withContext cached
+        if (cached.exists() && cached.length() > 0L) return@withContext cached
 
         if (downloadUrl.startsWith("content://") || downloadUrl.startsWith("file://")) {
             val temp = File(dir, "$safeName.tmp")
             val input = context.contentResolver.openInputStream(android.net.Uri.parse(downloadUrl))
                 ?: throw EbookContextException("Couldn't open the local book file.")
             input.use { inp -> FileOutputStream(temp).use { out -> inp.copyTo(out) } }
-            if (temp.length() < 1024L) {
+            if (temp.length() == 0L) {
                 temp.delete()
                 throw EbookContextException("The local book file was empty.")
             }
@@ -164,7 +164,7 @@ class EbookContextService @Inject constructor(
                 }
             }
         }
-        if (temp.length() < 1024L) {
+        if (temp.length() == 0L) {
             temp.delete()
             throw EbookContextException("Downloaded ebook was empty.")
         }

--- a/android/engine/src/main/java/com/enve/app/data/offline/ComicOfflineService.kt
+++ b/android/engine/src/main/java/com/enve/app/data/offline/ComicOfflineService.kt
@@ -120,9 +120,9 @@ class ComicOfflineService @Inject constructor(
             val input = context.contentResolver.openInputStream(android.net.Uri.parse(url))
                 ?: error("Couldn't open the local file for ${book.title}")
             input.use { inp -> FileOutputStream(target).use { out -> inp.copyTo(out) } }
-            if (target.length() < 1024) {
+            if (target.length() == 0L) {
                 target.delete()
-                error("Local file too small for ${book.title}")
+                error("Local file is empty for ${book.title}")
             }
             storage.commit(target)
             storage.saveManifest(book)
@@ -193,9 +193,9 @@ class ComicOfflineService @Inject constructor(
                 }
             }
 
-            if (target.length() < 1024) {
+            if (target.length() == 0L) {
                 target.delete()
-                error("Downloaded file too small for ${book.title}")
+                error("Downloaded file is empty for ${book.title}")
             }
 
             storage.commit(target)

--- a/android/engine/src/main/java/com/enve/app/data/offline/ComicOfflineStorage.kt
+++ b/android/engine/src/main/java/com/enve/app/data/offline/ComicOfflineStorage.kt
@@ -25,7 +25,7 @@ class ComicOfflineStorage @Inject constructor(
         val dir = bookDirectory(bookId)
         if (!dir.exists()) return false
         return dir.listFiles().orEmpty().any {
-            it.name.startsWith("book.") && it.length() > 1024 && it.name != "book.json"
+            it.name.startsWith("book.") && it.length() > 0L && it.name != "book.json"
         }
     }
 
@@ -33,7 +33,7 @@ class ComicOfflineStorage @Inject constructor(
         val dir = bookDirectory(bookId)
         if (!dir.exists()) return null
         return dir.listFiles().orEmpty()
-            .firstOrNull { it.name.startsWith("book.") && it.length() > 1024 && it.name != "book.json" }
+            .firstOrNull { it.name.startsWith("book.") && it.length() > 0L && it.name != "book.json" }
     }
 
     fun createTempFile(bookId: String, extension: String): File {
@@ -96,6 +96,6 @@ class ComicOfflineStorage @Inject constructor(
 
     private fun isDownloadedDir(dir: File): Boolean =
         dir.listFiles().orEmpty().any {
-            it.name.startsWith("book.") && it.length() > 1024 && it.name != "book.json"
+            it.name.startsWith("book.") && it.length() > 0L && it.name != "book.json"
         }
 }

--- a/android/engine/src/main/java/com/enve/app/data/provider/CloudTrackDurationService.kt
+++ b/android/engine/src/main/java/com/enve/app/data/provider/CloudTrackDurationService.kt
@@ -7,14 +7,18 @@ import com.enve.core.data.local.decodeAudioTracks
 import com.enve.core.data.local.encodeAudioTracksJson
 import com.enve.core.data.model.AudioTrack
 import com.enve.core.data.model.Book
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -22,6 +26,9 @@ import javax.inject.Singleton
 class CloudTrackDurationService @Inject constructor(
     private val bookExtras: BookExtrasDao,
 ) {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val activeProbes = ConcurrentHashMap.newKeySet<String>()
+
     suspend fun resolveDurations(book: Book, tracks: List<AudioTrack>): List<AudioTrack> {
         if (tracks.size <= 1 || tracks.all { it.durationMs > 0L }) return tracks
 
@@ -38,9 +45,16 @@ class CloudTrackDurationService @Inject constructor(
             }
         }
 
-        val resolved = if (merged.any { it.durationMs <= 0L }) probeMissing(merged) else merged
-        persistIfChanged(cacheKey, resolved, existing)
-        return resolved
+        if (merged.any { it.durationMs <= 0L } && activeProbes.add(cacheKey)) {
+            scope.launch {
+                try {
+                    persistIfChanged(cacheKey, probeMissing(merged))
+                } finally {
+                    activeProbes.remove(cacheKey)
+                }
+            }
+        }
+        return merged
     }
 
     private suspend fun probeMissing(tracks: List<AudioTrack>): List<AudioTrack> {
@@ -61,12 +75,13 @@ class CloudTrackDurationService @Inject constructor(
         }
     }
 
-    private suspend fun persistIfChanged(cacheKey: String, tracks: List<AudioTrack>, existing: BookExtras?) {
+    private suspend fun persistIfChanged(cacheKey: String, tracks: List<AudioTrack>) {
         if (tracks.none { it.durationMs > 0L }) return
 
         val payload = encodeAudioTracksJson(tracks.map { it.copy(contentUrl = null) })
-        if (payload == existing?.audioTracksJson) return
         withContext(Dispatchers.IO) {
+            val existing = bookExtras.get(cacheKey)
+            if (payload == existing?.audioTracksJson) return@withContext
             bookExtras.upsert(
                 BookExtras(
                     cacheKey = cacheKey,

--- a/android/engine/src/main/java/com/enve/app/data/repository/GrimmoryRepository.kt
+++ b/android/engine/src/main/java/com/enve/app/data/repository/GrimmoryRepository.kt
@@ -1626,7 +1626,7 @@ class GrimmoryRepository @Inject constructor(
                 resolveAgainst(ctx.serverUrl, bookId)
             }
 
-            else -> "${ctx.serverUrl}/api/v1/books/${bookId.grimmoryServerBookId()}/content?bookType=EPUB"
+            else -> grimmoryBookContentUrl(ctx.serverUrl, bookId.grimmoryServerBookId())
         }
     }
 
@@ -1640,7 +1640,7 @@ class GrimmoryRepository @Inject constructor(
         val epubFile = detail?.epubFile()
         return ProviderEbookResource(
 
-            url = "${ctx.serverUrl}/api/v1/books/$rawBookId/content?bookType=EPUB",
+            url = grimmoryBookContentUrl(ctx.serverUrl, rawBookId, bookType = "EPUB"),
             providerFileId = epubFile?.id,
         )
     }

--- a/android/engine/src/main/java/com/enve/app/data/repository/grimmory/GrimmoryHelpers.kt
+++ b/android/engine/src/main/java/com/enve/app/data/repository/grimmory/GrimmoryHelpers.kt
@@ -39,6 +39,17 @@ internal fun grimmoryCompanionAudiobookId(bookId: String): String =
     if (bookId.startsWith(GRIMMORY_COMPANION_AUDIOBOOK_ID_PREFIX)) bookId
     else "$GRIMMORY_COMPANION_AUDIOBOOK_ID_PREFIX$bookId"
 
+internal fun grimmoryBookContentUrl(
+    serverUrl: String,
+    bookId: String,
+    bookType: String? = null,
+): String {
+    val contentUrl = "${serverUrl.trimEnd('/')}/api/v1/books/$bookId/content"
+    return bookType?.takeIf { it.isNotBlank() }
+        ?.let { "$contentUrl?bookType=$it" }
+        ?: contentUrl
+}
+
 internal fun BookDetailDto.copyWithResolvedMediaType(): BookDetailDto = copy(primaryFileType = selectedFile()?.bookType ?: primaryFileType)
 
 internal fun BookDetailDto.resolvedMediaType(): AppMediaType = (selectedFile()?.bookType ?: primaryFileType).toMediaType()

--- a/android/engine/src/main/java/com/enve/app/data/sync/RecentlyPlayedSyncService.kt
+++ b/android/engine/src/main/java/com/enve/app/data/sync/RecentlyPlayedSyncService.kt
@@ -1,6 +1,7 @@
 package com.enve.app.data.sync
 
 import android.util.Log
+import kotlinx.coroutines.CancellationException
 import com.enve.core.data.sync.ProviderSyncStrategy
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -48,8 +49,10 @@ class RecentlyPlayedSyncService @Inject constructor(
             result.onSuccess {
                 pulled += it.pulled
                 pushed += it.pushed
+                failed.addAll(it.failedBackends)
             }.onFailure { error ->
-                Log.e(TAG, "Strategy '${strategy.id}' failed", error)
+                if (error is CancellationException) throw error
+                Log.e(TAG, "Strategy '${strategy.id}' failed")
                 failed.add(strategy.displayName)
             }
         }
@@ -63,7 +66,7 @@ class RecentlyPlayedSyncService @Inject constructor(
             attemptedStrategyCount = strategies.size,
             pulledItemCount = pulled,
             pushedItemCount = pushed,
-            failedStrategies = failed,
+            failedStrategies = failed.distinct(),
         )
     }
 

--- a/android/engine/src/main/java/com/enve/app/document/Fb2EpubConverter.kt
+++ b/android/engine/src/main/java/com/enve/app/document/Fb2EpubConverter.kt
@@ -1,0 +1,325 @@
+package com.enve.app.document
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Element
+import org.jsoup.nodes.Node
+import org.jsoup.nodes.TextNode
+import org.jsoup.parser.Parser
+import java.io.File
+import java.io.FileOutputStream
+import java.nio.charset.StandardCharsets
+import java.time.Instant
+import java.util.Base64
+import java.util.Locale
+import java.util.UUID
+import java.util.zip.CRC32
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+internal class Fb2EpubConverter {
+    private data class Metadata(
+        val title: String,
+        val author: String,
+        val publisher: String?,
+        val language: String,
+        val coverId: String?,
+    )
+
+    private data class Resource(
+        val sourceId: String,
+        val href: String,
+        val mediaType: String,
+        val data: ByteArray,
+    )
+
+    private data class Chapter(
+        val title: String,
+        val href: String,
+        val content: String,
+    )
+
+    fun convertToEpub(source: File, destination: File): File {
+        val document = try {
+            Jsoup.parse(source, null, "", Parser.xmlParser())
+        } catch (error: Exception) {
+            throw EbookNormalizationException("Could not parse FB2 file: ${error.message}", error)
+        }
+
+        val fictionBook = document.selectFirst("FictionBook, fictionbook")
+            ?: throw EbookNormalizationException("The file is not a valid FB2 document.")
+        val titleInfo = fictionBook.selectFirst("description > title-info")
+        val metadata = readMetadata(titleInfo)
+        val resources = readResources(fictionBook)
+        val resourcesById = resources.associateBy { it.sourceId }
+        val chapters = buildChapters(fictionBook, resourcesById, metadata.title)
+        if (chapters.isEmpty()) {
+            throw EbookNormalizationException("The FB2 file did not contain readable chapters.")
+        }
+
+        destination.parentFile?.mkdirs()
+        val tempFile = File(destination.parentFile ?: source.parentFile, "${destination.name}.tmp")
+        if (tempFile.exists()) tempFile.delete()
+
+        try {
+            ZipOutputStream(FileOutputStream(tempFile)).use { zip ->
+                zip.putStoredEntry("mimetype", "application/epub+zip".toByteArray(StandardCharsets.US_ASCII))
+                zip.putDeflatedEntry("META-INF/container.xml", containerXml().toByteArray(StandardCharsets.UTF_8))
+                zip.putDeflatedEntry(
+                    "OEBPS/content.opf",
+                    contentOpf(metadata, chapters, resources).toByteArray(StandardCharsets.UTF_8),
+                )
+                zip.putDeflatedEntry("OEBPS/nav.xhtml", navDocument(chapters).toByteArray(StandardCharsets.UTF_8))
+                chapters.forEach { chapter ->
+                    zip.putDeflatedEntry("OEBPS/${chapter.href}", chapter.content.toByteArray(StandardCharsets.UTF_8))
+                }
+                resources.forEach { resource ->
+                    zip.putDeflatedEntry("OEBPS/${resource.href}", resource.data)
+                }
+            }
+        } catch (error: Exception) {
+            tempFile.delete()
+            throw EbookNormalizationException("Could not convert FB2 file: ${error.message}", error)
+        }
+
+        if (destination.exists()) destination.delete()
+        if (!tempFile.renameTo(destination)) {
+            tempFile.copyTo(destination, overwrite = true)
+            tempFile.delete()
+        }
+        return destination
+    }
+
+    private fun readMetadata(titleInfo: Element?): Metadata {
+        val title = titleInfo?.selectFirst("book-title")?.text()?.trim().orEmpty().ifBlank { "Untitled" }
+        val authors = titleInfo?.select("author").orEmpty().mapNotNull { author ->
+            listOf("first-name", "middle-name", "last-name", "nickname")
+                .mapNotNull { part -> author.selectFirst(part)?.text()?.trim()?.takeIf(String::isNotBlank) }
+                .joinToString(" ")
+                .takeIf(String::isNotBlank)
+        }
+        val coverHref = titleInfo?.selectFirst("coverpage image")?.hrefAttribute()
+        return Metadata(
+            title = title,
+            author = authors.joinToString(", ").ifBlank { "Unknown Author" },
+            publisher = titleInfo?.selectFirst("publisher")?.text()?.trim()?.takeIf(String::isNotBlank),
+            language = titleInfo?.selectFirst("lang")?.text()?.trim()?.takeIf(String::isNotBlank) ?: "en",
+            coverId = coverHref?.removePrefix("#")?.takeIf(String::isNotBlank),
+        )
+    }
+
+    private fun readResources(fictionBook: Element): List<Resource> {
+        val usedNames = mutableSetOf<String>()
+        return fictionBook.select("binary[id]").mapNotNull { binary ->
+            val id = binary.attr("id").trim().takeIf(String::isNotBlank) ?: return@mapNotNull null
+            val mediaType = binary.attr("content-type").trim().lowercase(Locale.US)
+                .takeIf(String::isNotBlank) ?: "application/octet-stream"
+            val data = try {
+                Base64.getMimeDecoder().decode(binary.text())
+            } catch (_: IllegalArgumentException) {
+                return@mapNotNull null
+            }
+            if (data.isEmpty()) return@mapNotNull null
+            val fileName = uniqueFileName(id.safeFileName(mediaType.fileExtension()), usedNames)
+            Resource(id, "resources/$fileName", mediaType, data)
+        }
+    }
+
+    private fun buildChapters(
+        fictionBook: Element,
+        resourcesById: Map<String, Resource>,
+        bookTitle: String,
+    ): List<Chapter> {
+        val bodies = fictionBook.children().filter { it.normalizedTagName() == "body" }
+        val roots = bodies.flatMap { body ->
+            body.children().filter { it.normalizedTagName() == "section" }.ifEmpty { listOf(body) }
+        }
+        return roots.mapIndexedNotNull { index, root ->
+            val title = root.directChild("title")?.text()?.trim()
+                ?.takeIf(String::isNotBlank)
+                ?: if (roots.size == 1) bookTitle else "Chapter ${index + 1}"
+            val body = renderChildren(root, resourcesById, headingLevel = 1).trim()
+            if (body.isBlank()) return@mapIndexedNotNull null
+            Chapter(
+                title = title,
+                href = "chapter_${index.toString().padStart(4, '0')}.xhtml",
+                content = chapterDocument(title, body),
+            )
+        }
+    }
+
+    private fun renderChildren(element: Element, resourcesById: Map<String, Resource>, headingLevel: Int): String =
+        element.childNodes().joinToString("") { node -> renderNode(node, resourcesById, headingLevel) }
+
+    private fun renderNode(node: Node, resourcesById: Map<String, Resource>, headingLevel: Int): String = when (node) {
+        is TextNode -> node.text().escapeXml()
+        !is Element -> ""
+        else -> {
+            val children = { renderChildren(node, resourcesById, headingLevel) }
+            when (node.normalizedTagName()) {
+                "title" -> {
+                    val level = headingLevel.coerceIn(1, 6)
+                    "<h$level>${node.text().trim().escapeXml()}</h$level>"
+                }
+                "section" -> "<section>${renderChildren(node, resourcesById, headingLevel + 1)}</section>"
+                "p" -> "<p>${children()}</p>"
+                "subtitle" -> "<h${headingLevel.coerceIn(2, 6)}>${children()}</h${headingLevel.coerceIn(2, 6)}>"
+                "emphasis" -> "<em>${children()}</em>"
+                "strong" -> "<strong>${children()}</strong>"
+                "strikethrough" -> "<s>${children()}</s>"
+                "sub" -> "<sub>${children()}</sub>"
+                "sup" -> "<sup>${children()}</sup>"
+                "code" -> "<code>${children()}</code>"
+                "a" -> {
+                    val href = node.hrefAttribute()?.escapeXml().orEmpty()
+                    if (href.isBlank()) children() else "<a href=\"$href\">${children()}</a>"
+                }
+                "image" -> {
+                    val sourceId = node.hrefAttribute()?.removePrefix("#")
+                    val resource = sourceId?.let(resourcesById::get)
+                    resource?.let { "<figure><img src=\"${it.href.escapeXml()}\" alt=\"\"/></figure>" }.orEmpty()
+                }
+                "empty-line" -> "<br/>"
+                "poem" -> "<section class=\"poem\">${children()}</section>"
+                "stanza" -> "<div class=\"stanza\">${children()}</div>"
+                "v" -> "<p class=\"verse\">${children()}</p>"
+                "cite", "epigraph" -> "<blockquote>${children()}</blockquote>"
+                "annotation" -> "<aside>${children()}</aside>"
+                "text-author" -> "<p class=\"text-author\">${children()}</p>"
+                "date" -> "<time>${children()}</time>"
+                "binary", "description" -> ""
+                else -> children()
+            }
+        }
+    }
+
+    private fun chapterDocument(title: String, body: String): String =
+        """
+        <?xml version="1.0" encoding="utf-8"?>
+        <!DOCTYPE html>
+        <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
+        <head><meta charset="utf-8"/><title>${title.escapeXml()}</title></head>
+        <body>$body</body>
+        </html>
+        """.trimIndent()
+
+    private fun contentOpf(metadata: Metadata, chapters: List<Chapter>, resources: List<Resource>): String {
+        val cover = metadata.coverId?.let { coverId -> resources.firstOrNull { it.sourceId == coverId } }
+        return buildString {
+            append("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n")
+            append("<package xmlns=\"http://www.idpf.org/2007/opf\" version=\"3.0\" unique-identifier=\"bookid\">\n")
+            append("<metadata xmlns:dc=\"http://purl.org/dc/elements/1.1/\">\n")
+            append("<dc:identifier id=\"bookid\">urn:uuid:").append(UUID.randomUUID()).append("</dc:identifier>\n")
+            append("<dc:title>").append(metadata.title.escapeXml()).append("</dc:title>\n")
+            append("<dc:creator>").append(metadata.author.escapeXml()).append("</dc:creator>\n")
+            metadata.publisher?.let { append("<dc:publisher>").append(it.escapeXml()).append("</dc:publisher>\n") }
+            append("<dc:language>").append(metadata.language.escapeXml()).append("</dc:language>\n")
+            append("<meta property=\"dcterms:modified\">").append(Instant.now()).append("</meta>\n")
+            append("</metadata>\n<manifest>\n")
+            append("<item id=\"nav\" href=\"nav.xhtml\" media-type=\"application/xhtml+xml\" properties=\"nav\"/>\n")
+            chapters.forEachIndexed { index, chapter ->
+                append("<item id=\"chapter_").append(index).append("\" href=\"")
+                    .append(chapter.href.escapeXml()).append("\" media-type=\"application/xhtml+xml\"/>\n")
+            }
+            resources.forEachIndexed { index, resource ->
+                append("<item id=\"resource_").append(index).append("\" href=\"")
+                    .append(resource.href.escapeXml()).append("\" media-type=\"")
+                    .append(resource.mediaType.escapeXml()).append("\"")
+                if (resource == cover) append(" properties=\"cover-image\"")
+                append("/>\n")
+            }
+            append("</manifest>\n<spine>\n")
+            chapters.indices.forEach { index -> append("<itemref idref=\"chapter_").append(index).append("\"/>\n") }
+            append("</spine>\n</package>")
+        }
+    }
+
+    private fun navDocument(chapters: List<Chapter>): String = buildString {
+        append("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n")
+        append("<!DOCTYPE html>\n")
+        append("<html xmlns=\"http://www.w3.org/1999/xhtml\" xmlns:epub=\"http://www.idpf.org/2007/ops\">\n")
+        append("<head><meta charset=\"utf-8\"/><title>Table of Contents</title></head>\n")
+        append("<body><nav epub:type=\"toc\" id=\"toc\"><ol>\n")
+        chapters.forEach { chapter ->
+            append("<li><a href=\"").append(chapter.href.escapeXml()).append("\">")
+                .append(chapter.title.escapeXml()).append("</a></li>\n")
+        }
+        append("</ol></nav></body>\n</html>")
+    }
+
+    private fun containerXml(): String =
+        """
+        <?xml version="1.0" encoding="utf-8"?>
+        <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+            <rootfiles>
+                <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+            </rootfiles>
+        </container>
+        """.trimIndent()
+
+    private fun Element.normalizedTagName(): String = tagName().substringAfter(':').lowercase(Locale.US)
+
+    private fun Element.directChild(tagName: String): Element? =
+        children().firstOrNull { it.normalizedTagName() == tagName }
+
+    private fun Element.hrefAttribute(): String? =
+        sequenceOf("xlink:href", "l:href", "href")
+            .map(::attr)
+            .firstOrNull(String::isNotBlank)
+
+    private fun String.safeFileName(extension: String): String {
+        val safe = replace(Regex("[^a-zA-Z0-9._-]"), "_").ifBlank { "resource" }
+        return if (safe.contains('.')) safe else "$safe.$extension"
+    }
+
+    private fun String.fileExtension(): String = when (this) {
+        "image/jpeg" -> "jpg"
+        "image/png" -> "png"
+        "image/gif" -> "gif"
+        "image/svg+xml" -> "svg"
+        else -> "bin"
+    }
+
+    private fun uniqueFileName(candidate: String, usedNames: MutableSet<String>): String {
+        if (usedNames.add(candidate)) return candidate
+        val base = candidate.substringBeforeLast('.', candidate)
+        val extension = candidate.substringAfterLast('.', "")
+        var index = 1
+        while (true) {
+            val next = if (extension.isBlank()) "$base-$index" else "$base-$index.$extension"
+            if (usedNames.add(next)) return next
+            index++
+        }
+    }
+
+    private fun ZipOutputStream.putStoredEntry(name: String, data: ByteArray) {
+        val checksum = CRC32().apply { update(data) }
+        val entry = ZipEntry(name).apply {
+            method = ZipEntry.STORED
+            size = data.size.toLong()
+            compressedSize = data.size.toLong()
+            crc = checksum.value
+        }
+        putNextEntry(entry)
+        write(data)
+        closeEntry()
+    }
+
+    private fun ZipOutputStream.putDeflatedEntry(name: String, data: ByteArray) {
+        putNextEntry(ZipEntry(name))
+        write(data)
+        closeEntry()
+    }
+
+    private fun String.escapeXml(): String = buildString(length) {
+        for (character in this@escapeXml) {
+            when (character) {
+                '&' -> append("&amp;")
+                '<' -> append("&lt;")
+                '>' -> append("&gt;")
+                '"' -> append("&quot;")
+                '\'' -> append("&apos;")
+                else -> append(character)
+            }
+        }
+    }
+}

--- a/android/engine/src/main/java/com/enve/app/document/OnDeviceEbookNormalizer.kt
+++ b/android/engine/src/main/java/com/enve/app/document/OnDeviceEbookNormalizer.kt
@@ -71,9 +71,7 @@ class OnDeviceEbookNormalizer(
                 )
                 converter.convertToEpub(source, normalized)
             }
-            EbookSourceFormat.FB2 -> throw EbookNormalizationException(
-                "On-device FB2 conversion is not bundled yet."
-            )
+            EbookSourceFormat.FB2 -> Fb2EpubConverter().convertToEpub(source, normalized)
             EbookSourceFormat.UNKNOWN -> throw EbookNormalizationException(
                 "Unknown ebook format."
             )

--- a/android/engine/src/main/java/com/enve/app/hearth/BookOrbitFacadeImpl.kt
+++ b/android/engine/src/main/java/com/enve/app/hearth/BookOrbitFacadeImpl.kt
@@ -163,9 +163,7 @@ class BookOrbitFacadeImpl @Inject constructor(
         title = title,
         authors = authors.joinToString(", ").takeIf { it.isNotBlank() },
         coverUrl = coverUrl,
-        seriesLabel = seriesIndex?.let { index ->
-            if (index % 1.0 == 0.0) "Book ${index.toInt()}" else "Book $index"
-        },
+        seriesLabel = seriesIndex?.let { "Book $it" },
     )
 
     private fun BookOrbitHighlightQuery.toFilter(): BookOrbitAnnotationHubFilter = BookOrbitAnnotationHubFilter(

--- a/android/engine/src/main/java/com/enve/app/playback/AutoMediaBrowserHelper.kt
+++ b/android/engine/src/main/java/com/enve/app/playback/AutoMediaBrowserHelper.kt
@@ -50,6 +50,8 @@ class AutoMediaBrowserHelper @Inject constructor(
     companion object {
         const val ROOT_ID = "enve_root"
         const val SHELF_IN_PROGRESS = "enve_shelf_in_progress"
+        const val SHELF_LIBRARY = "enve_shelf_library"
+        const val SHELF_DOWNLOADS = "enve_shelf_downloads"
         const val SHELF_RECENT = "enve_shelf_recent"
 
         private const val BOOK_PREFIX = "book:"
@@ -66,6 +68,57 @@ class AutoMediaBrowserHelper @Inject constructor(
 
         fun mediaIdForTrack(cacheKey: String, trackIndex: Int): String =
             "$BOOK_PREFIX$cacheKey#track:$trackIndex"
+
+        fun mediaIdForChapter(cacheKey: String, chapterIndex: Int): String =
+            "$BOOK_PREFIX$cacheKey#chapter:$chapterIndex"
+
+        fun isChapterMediaId(mediaId: String): Boolean =
+            mediaId.startsWith(BOOK_PREFIX) && "#chapter:" in mediaId
+
+        internal data class ChapterSegment(
+            val chapter: Chapter,
+            val startMs: Long,
+            val endMs: Long,
+        )
+
+        internal fun chapterSegments(
+            chapters: List<Chapter>,
+            totalDurationMs: Long,
+        ): List<ChapterSegment> {
+            if (chapters.size < 2) return emptyList()
+            val segments = chapters.mapIndexed { index, chapter ->
+                val startMs = chapter.startTime.coerceAtLeast(0L) * 1000L
+                val nextStartMs = chapters.getOrNull(index + 1)
+                    ?.startTime
+                    ?.coerceAtLeast(0L)
+                    ?.times(1000L)
+                val declaredEndMs = chapter.endTime.coerceAtLeast(0L) * 1000L
+                val endMs = when {
+                    nextStartMs != null && nextStartMs > startMs -> nextStartMs
+                    declaredEndMs > startMs -> declaredEndMs
+                    index == chapters.lastIndex && totalDurationMs > startMs -> totalDurationMs
+                    else -> return emptyList()
+                }
+                ChapterSegment(chapter, startMs, endMs)
+            }
+            return segments.takeIf { items ->
+                items.zipWithNext().all { (current, next) -> next.startMs >= current.endMs }
+            }.orEmpty()
+        }
+
+        internal fun startOffsetInSegments(
+            segments: List<ChapterSegment>,
+            resumeMs: Long,
+        ): Pair<Int, Long> {
+            if (segments.isEmpty()) return 0 to resumeMs.coerceAtLeast(0L)
+            val absoluteMs = resumeMs.coerceAtLeast(0L)
+            val index = segments.indexOfLast { absoluteMs >= it.startMs }
+                .coerceAtLeast(0)
+                .coerceAtMost(segments.lastIndex)
+            val segment = segments[index]
+            return index to (absoluteMs - segment.startMs)
+                .coerceIn(0L, segment.endMs - segment.startMs)
+        }
     }
 
     fun buildRoot(): MediaItem = MediaItem.Builder()
@@ -89,12 +142,24 @@ class AutoMediaBrowserHelper @Inject constructor(
                     R.drawable.ic_car_continue,
                 ),
                 shelfItem(
+                    SHELF_LIBRARY,
+                    R.string.android_auto_library,
+                    R.drawable.ic_car_library,
+                ),
+                shelfItem(
+                    SHELF_DOWNLOADS,
+                    R.string.android_auto_downloads,
+                    R.drawable.ic_car_downloads,
+                ),
+                shelfItem(
                     SHELF_RECENT,
                     R.string.android_auto_recently_added,
                     R.drawable.ic_car_recent,
                 ),
             )
             SHELF_IN_PROGRESS -> loadShelf { bookCacheDao.getInProgressAudiobooksOnce(SHELF_LIMIT) }
+            SHELF_LIBRARY -> loadShelf { bookCacheDao.getAudiobooksForCar(SHELF_LIMIT) }
+            SHELF_DOWNLOADS -> loadShelf { bookCacheDao.getDownloadedAudiobooksForCar(SHELF_LIMIT) }
             SHELF_RECENT -> loadShelf { bookCacheDao.getRecentlyAddedAudiobooks(SHELF_LIMIT) }
             else -> {
                 Log.w(TAG, "getChildren: unknown parentId='$parentId'")
@@ -110,6 +175,16 @@ class AutoMediaBrowserHelper @Inject constructor(
                 SHELF_IN_PROGRESS,
                 R.string.android_auto_continue_listening,
                 R.drawable.ic_car_continue,
+            )
+            SHELF_LIBRARY -> shelfItem(
+                SHELF_LIBRARY,
+                R.string.android_auto_library,
+                R.drawable.ic_car_library,
+            )
+            SHELF_DOWNLOADS -> shelfItem(
+                SHELF_DOWNLOADS,
+                R.string.android_auto_downloads,
+                R.drawable.ic_car_downloads,
             )
             SHELF_RECENT -> shelfItem(
                 SHELF_RECENT,
@@ -233,10 +308,28 @@ class AutoMediaBrowserHelper @Inject constructor(
         providerSessionId: String?,
     ): ResolvedPlayback {
         val artworkUri = artworkUriFor(book)
-        val items = tracks.map { playableItem(book, it, artworkUri) }
-        val (index, offsetMs) = startOffsetInTracks(tracks, resumeMs)
-        val durationSec = book.duration.takeIf { it > 0L }
-            ?: tracks.sumOf { it.durationMs.coerceAtLeast(0L) } / 1000L
+        val totalDurationMs = book.duration
+            .takeIf { it > 0L }
+            ?.times(1000L)
+            ?: tracks.sumOf { it.durationMs.coerceAtLeast(0L) }
+        val segments = if (tracks.size == 1) {
+            chapterSegments(chapters, totalDurationMs)
+        } else {
+            emptyList()
+        }
+        val items = if (segments.isNotEmpty()) {
+            segments.map { segment ->
+                chapterPlayableItem(book, tracks.single(), segment, artworkUri)
+            }
+        } else {
+            tracks.map { playableItem(book, it, artworkUri) }
+        }
+        val (index, offsetMs) = if (segments.isNotEmpty()) {
+            startOffsetInSegments(segments, resumeMs)
+        } else {
+            startOffsetInTracks(tracks, resumeMs)
+        }
+        val durationSec = totalDurationMs / 1000L
         return ResolvedPlayback(
             items = items,
             startIndex = index,
@@ -337,7 +430,7 @@ class AutoMediaBrowserHelper @Inject constructor(
                     Bundle().apply {
                         putInt(
                             MediaConstants.EXTRAS_KEY_CONTENT_STYLE_PLAYABLE,
-                            MediaConstants.EXTRAS_VALUE_CONTENT_STYLE_GRID_ITEM,
+                            MediaConstants.EXTRAS_VALUE_CONTENT_STYLE_LIST_ITEM,
                         )
                     }
                 )
@@ -389,6 +482,38 @@ class AutoMediaBrowserHelper @Inject constructor(
             .setMediaId(mediaIdForTrack(book.uniqueKey, track.index))
             .setUri(track.contentUrl.orEmpty())
             .setMediaMetadata(meta)
+            .build()
+    }
+
+    private fun chapterPlayableItem(
+        book: Book,
+        track: AudioTrack,
+        segment: ChapterSegment,
+        artworkUri: Uri?,
+    ): MediaItem {
+        val durationMs = segment.endMs - segment.startMs
+        val metadata = MediaMetadata.Builder()
+            .setTitle(segment.chapter.title)
+            .setSubtitle(book.title)
+            .setArtist(book.author)
+            .setAlbumTitle(book.title)
+            .setIsBrowsable(false)
+            .setIsPlayable(true)
+            .setMediaType(MediaMetadata.MEDIA_TYPE_AUDIO_BOOK_CHAPTER)
+            .setDurationMs(durationMs)
+            .setExtras(carMetadataExtras(book))
+            .apply { artworkUri?.let(::setArtworkUri) }
+            .build()
+        return MediaItem.Builder()
+            .setMediaId(mediaIdForChapter(book.uniqueKey, segment.chapter.index))
+            .setUri(track.contentUrl.orEmpty())
+            .setClippingConfiguration(
+                MediaItem.ClippingConfiguration.Builder()
+                    .setStartPositionMs(segment.startMs)
+                    .setEndPositionMs(segment.endMs)
+                    .build()
+            )
+            .setMediaMetadata(metadata)
             .build()
     }
 

--- a/android/engine/src/main/java/com/enve/app/playback/PlaybackService.kt
+++ b/android/engine/src/main/java/com/enve/app/playback/PlaybackService.kt
@@ -1143,6 +1143,12 @@ class PlaybackService : MediaLibraryService() {
         }
     }
 
+    private fun usesChapterMediaItems(
+        player: Player,
+        snapshot: PlaybackChapterStore.Snapshot,
+    ): Boolean = snapshot.usesMediaItemIndexes(player.mediaItemCount) ||
+        player.currentMediaItem?.mediaId?.let(AutoMediaBrowserHelper::isChapterMediaId) == true
+
     private fun applyChapterMetadata(snapshot: PlaybackChapterStore.Snapshot) {
 
         if (activePlaybackTarget() === castPlayer) return
@@ -1152,7 +1158,7 @@ class PlaybackService : MediaLibraryService() {
         val currentCacheKey = AutoMediaBrowserHelper.cacheKeyFrom(current.mediaId) ?: return
         if (snapshot.cacheKey != currentCacheKey) return
 
-        val chapterIndex = if (snapshot.usesMediaItemIndexes(player.mediaItemCount)) {
+        val chapterIndex = if (usesChapterMediaItems(player, snapshot)) {
             player.currentMediaItemIndex
         } else {
             snapshot.chapterIndexAt(absolutePositionSec(player))
@@ -1381,7 +1387,7 @@ class PlaybackService : MediaLibraryService() {
         private fun seekToChapter(player: Player, next: Boolean): Boolean {
             val snapshot = chapterStore?.snapshot?.value ?: return false
             if (snapshot.chapters.isEmpty()) return false
-            if (snapshot.usesMediaItemIndexes(player.mediaItemCount)) {
+            if (usesChapterMediaItems(player, snapshot)) {
                 val currentIndex = player.currentMediaItemIndex
                     .coerceIn(0, snapshot.chapters.lastIndex)
                 val targetIndex = if (next) {
@@ -1426,7 +1432,7 @@ class PlaybackService : MediaLibraryService() {
                 )
                 putInt(
                     MediaConstants.EXTRAS_KEY_CONTENT_STYLE_PLAYABLE,
-                    MediaConstants.EXTRAS_VALUE_CONTENT_STYLE_GRID_ITEM,
+                    MediaConstants.EXTRAS_VALUE_CONTENT_STYLE_LIST_ITEM,
                 )
             }
             val rootParams = LibraryParams.Builder()

--- a/android/engine/src/main/res/drawable/ic_car_downloads.xml
+++ b/android/engine/src/main/res/drawable/ic_car_downloads.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@color/enve_ember"
+        android:pathData="M11,3 L13,3 L13,12 L16.5,8.5 L18,10 L12,16 L6,10 L7.5,8.5 L11,12 Z M4,18 L20,18 L20,21 L4,21 Z" />
+</vector>

--- a/android/engine/src/main/res/drawable/ic_car_library.xml
+++ b/android/engine/src/main/res/drawable/ic_car_library.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@color/enve_ember"
+        android:pathData="M4,3 L10,3 C11.1,3 12,3.9 12,5 C12,3.9 12.9,3 14,3 L20,3 L20,19 L14,19 C12.9,19 12,19.9 12,21 C12,19.9 11.1,19 10,19 L4,19 Z M6,5 L6,17 L10,17 C10.7,17 11.4,17.2 12,17.6 L12,6.4 C11.4,5.5 10.8,5 10,5 Z M14,5 C13.2,5 12.6,5.5 12,6.4 L12,17.6 C12.6,17.2 13.3,17 14,17 L18,17 L18,5 Z" />
+</vector>

--- a/android/engine/src/main/res/values/strings.xml
+++ b/android/engine/src/main/res/values/strings.xml
@@ -11,5 +11,7 @@
     <string name="android_auto_playback_speed">Playback speed %1$s×</string>
     <string name="android_auto_add_bookmark">Add bookmark</string>
     <string name="android_auto_continue_listening">Continue Listening</string>
+    <string name="android_auto_library">Library</string>
+    <string name="android_auto_downloads">Downloads</string>
     <string name="android_auto_recently_added">Recently Added</string>
 </resources>

--- a/android/engine/src/test/java/com/enve/app/data/repository/grimmory/GrimmoryContentUrlTest.kt
+++ b/android/engine/src/test/java/com/enve/app/data/repository/grimmory/GrimmoryContentUrlTest.kt
@@ -1,0 +1,22 @@
+package com.enve.app.data.repository.grimmory
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class GrimmoryContentUrlTest {
+    @Test
+    fun `download URL lets Grimmory select the primary file type`() {
+        assertEquals(
+            "http://grimmory.test/api/v1/books/42/content",
+            grimmoryBookContentUrl("http://grimmory.test/", "42"),
+        )
+    }
+
+    @Test
+    fun `EPUB resource URL keeps its explicit file type`() {
+        assertEquals(
+            "http://grimmory.test/api/v1/books/42/content?bookType=EPUB",
+            grimmoryBookContentUrl("http://grimmory.test", "42", bookType = "EPUB"),
+        )
+    }
+}

--- a/android/engine/src/test/java/com/enve/app/document/Fb2EpubConverterTest.kt
+++ b/android/engine/src/test/java/com/enve/app/document/Fb2EpubConverterTest.kt
@@ -1,0 +1,85 @@
+package com.enve.app.document
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.util.zip.ZipFile
+
+class Fb2EpubConverterTest {
+    @Test
+    fun convertsMetadataChaptersFormattingAndImages() {
+        val directory = Files.createTempDirectory("fb2-converter-test").toFile()
+        try {
+            val source = directory.resolve("source.fb2").apply { writeText(sampleFb2) }
+            val destination = directory.resolve("converted.epub")
+
+            Fb2EpubConverter().convertToEpub(source, destination)
+
+            assertTrue(destination.isFile)
+            ZipFile(destination).use { epub ->
+                assertEquals(
+                    "application/epub+zip",
+                    epub.getInputStream(epub.getEntry("mimetype")).readBytes().toString(StandardCharsets.US_ASCII),
+                )
+                val packageDocument = epub.readText("OEBPS/content.opf")
+                assertTrue(packageDocument.contains("<dc:title>Fixture &amp; Test</dc:title>"))
+                assertTrue(packageDocument.contains("<dc:creator>Ada Lovelace</dc:creator>"))
+                assertTrue(packageDocument.contains("properties=\"cover-image\""))
+
+                val chapter = epub.readText("OEBPS/chapter_0000.xhtml")
+                assertTrue(chapter.contains("<h1>Opening</h1>"))
+                assertTrue(chapter.contains("A <em>formatted</em> paragraph."))
+                assertTrue(chapter.contains("resources/cover.png"))
+                assertTrue(epub.getEntry("OEBPS/resources/cover.png") != null)
+            }
+        } finally {
+            directory.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun rejectsFilesThatAreNotFb2() {
+        val directory = Files.createTempDirectory("fb2-converter-invalid-test").toFile()
+        try {
+            val source = directory.resolve("source.fb2").apply { writeText("<book><p>Not FB2</p></book>") }
+            try {
+                Fb2EpubConverter().convertToEpub(source, directory.resolve("converted.epub"))
+                fail("Expected EbookNormalizationException")
+            } catch (error: EbookNormalizationException) {
+                assertTrue(error.message.orEmpty().contains("valid FB2"))
+            }
+        } finally {
+            directory.deleteRecursively()
+        }
+    }
+
+    private fun ZipFile.readText(path: String): String =
+        getInputStream(getEntry(path)).readBytes().toString(StandardCharsets.UTF_8)
+
+    private companion object {
+        const val sampleFb2 = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <FictionBook xmlns="http://www.gribuser.ru/xml/fictionbook/2.0" xmlns:l="http://www.w3.org/1999/xlink">
+              <description>
+                <title-info>
+                  <book-title>Fixture &amp; Test</book-title>
+                  <author><first-name>Ada</first-name><last-name>Lovelace</last-name></author>
+                  <lang>en</lang>
+                  <coverpage><image l:href="#cover"/></coverpage>
+                </title-info>
+              </description>
+              <body>
+                <section>
+                  <title><p>Opening</p></title>
+                  <p>A <emphasis>formatted</emphasis> paragraph.</p>
+                  <image l:href="#cover"/>
+                </section>
+              </body>
+              <binary id="cover" content-type="image/png">iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=</binary>
+            </FictionBook>
+        """
+    }
+}

--- a/android/engine/src/test/java/com/enve/app/playback/AndroidAutoMediaTest.kt
+++ b/android/engine/src/test/java/com/enve/app/playback/AndroidAutoMediaTest.kt
@@ -1,8 +1,10 @@
 package com.enve.app.playback
 
 import androidx.media3.common.MimeTypes
+import com.enve.core.data.model.Chapter
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class AndroidAutoMediaTest {
@@ -14,6 +16,31 @@ class AndroidAutoMediaTest {
         assertNotEquals(first, second)
         assertEquals("server:book", AutoMediaBrowserHelper.cacheKeyFrom(first))
         assertEquals("server:book", AutoMediaBrowserHelper.cacheKeyFrom(second))
+    }
+
+    @Test
+    fun `chapter media IDs remain unique while resolving to the same book`() {
+        val first = AutoMediaBrowserHelper.mediaIdForChapter("server:book", 0)
+        val second = AutoMediaBrowserHelper.mediaIdForChapter("server:book", 1)
+
+        assertNotEquals(first, second)
+        assertTrue(AutoMediaBrowserHelper.isChapterMediaId(first))
+        assertEquals("server:book", AutoMediaBrowserHelper.cacheKeyFrom(first))
+    }
+
+    @Test
+    fun `single file chapters become resumable queue segments`() {
+        val segments = AutoMediaBrowserHelper.chapterSegments(
+            chapters = listOf(
+                Chapter(index = 0, title = "Opening", startTime = 0, endTime = 30),
+                Chapter(index = 1, title = "One", startTime = 30, endTime = 90),
+                Chapter(index = 2, title = "Two", startTime = 90, endTime = 150),
+            ),
+            totalDurationMs = 150_000,
+        )
+
+        assertEquals(listOf(30_000L, 60_000L, 60_000L), segments.map { it.endMs - it.startMs })
+        assertEquals(1 to 15_000L, AutoMediaBrowserHelper.startOffsetInSegments(segments, 45_000L))
     }
 
     @Test

--- a/android/hearth-ui/src/main/java/com/enve/hearth/design/CoverTile.kt
+++ b/android/hearth-ui/src/main/java/com/enve/hearth/design/CoverTile.kt
@@ -31,8 +31,14 @@ import coil.ImageLoader
 import coil.compose.AsyncImage
 import coil.request.CachePolicy
 import coil.request.ImageRequest
+import com.enve.core.data.model.AppMediaType
 
 val LocalHearthImageLoader = staticCompositionLocalOf<ImageLoader?> { null }
+
+internal fun coverAspectRatio(mediaType: AppMediaType?): Float = when (mediaType) {
+    AppMediaType.AUDIOBOOK, AppMediaType.PODCAST -> 1f
+    else -> 2f / 3f
+}
 
 @Composable
 fun CoverTile(
@@ -40,7 +46,7 @@ fun CoverTile(
     modifier: Modifier = Modifier,
     ambient: Color = Hearth.palette.ember,
     contentDescription: String? = null,
-    aspect: Float = 2f / 3f,
+    mediaType: AppMediaType? = null,
     progress: Float = 0f,
     isFinished: Boolean = false,
 ) {
@@ -57,7 +63,7 @@ fun CoverTile(
         .takeIf(String::isNotEmpty)
 
     val shaped = modifier
-        .aspectRatio(aspect)
+        .aspectRatio(coverAspectRatio(mediaType))
         .then(
             if (eink.borderInsteadOfShadow) {
                 Modifier.border(1.5.dp, palette.text, shape)

--- a/android/hearth-ui/src/main/java/com/enve/hearth/detail/BookDetailScreen.kt
+++ b/android/hearth-ui/src/main/java/com/enve/hearth/detail/BookDetailScreen.kt
@@ -1491,7 +1491,12 @@ private fun DetailHeader(b: Book, ambientColor: Color, onBack: () -> Unit) {
             }
             Column(Modifier.fillMaxWidth().padding(horizontal = Hearth.Spacing.XL), horizontalAlignment = Alignment.CenterHorizontally) {
                 val coverWidth = if (b.mediaType == AppMediaType.EBOOK) 156.dp else 112.dp
-                CoverTile(model = b.coverUrl, ambient = ambientColor, modifier = Modifier.width(coverWidth))
+                CoverTile(
+                    model = b.coverUrl,
+                    ambient = ambientColor,
+                    mediaType = b.mediaType,
+                    modifier = Modifier.width(coverWidth),
+                )
                 Spacer(Modifier.height(Hearth.Spacing.M))
                 Text(
                     b.title,
@@ -1674,7 +1679,11 @@ private fun BookShelfRow(title: String, books: List<Book>, onOpen: (Book) -> Uni
             horizontalArrangement = Arrangement.spacedBy(Hearth.Spacing.M),
         ) {
             items(books, key = { it.id + (it.connectionId ?: "") }) { book ->
-                CoverTile(model = book.coverUrl, modifier = Modifier.width(108.dp).clickable { onOpen(book) })
+                CoverTile(
+                    model = book.coverUrl,
+                    mediaType = book.mediaType,
+                    modifier = Modifier.width(108.dp).clickable { onOpen(book) },
+                )
             }
         }
     }

--- a/android/hearth-ui/src/main/java/com/enve/hearth/home/HearthHomeScreen.kt
+++ b/android/hearth-ui/src/main/java/com/enve/hearth/home/HearthHomeScreen.kt
@@ -247,7 +247,7 @@ private fun HeroSection(book: Book, sourceName: String, isPlaying: Boolean, onCo
                 CoverTile(
                     model = book.coverUrl,
                     ambient = tint,
-                    aspect = if (book.mediaType == AppMediaType.EBOOK) 2f / 3f else 1f,
+                    mediaType = book.mediaType,
                     modifier = Modifier.width(if (compact) 106.dp else 132.dp).clickable(onClick = onOpen),
                 )
                 Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(Hearth.Spacing.S)) {
@@ -376,6 +376,7 @@ private fun ShelfCard(book: Book, showProgress: Boolean, onOpen: (Book) -> Unit)
     ) {
         CoverTile(
             model = book.coverUrl,
+            mediaType = book.mediaType,
             modifier = if (showProgress) {
                 Modifier.fillMaxWidth()
             } else {

--- a/android/hearth-ui/src/main/java/com/enve/hearth/journal/HearthCompletionCenterScreen.kt
+++ b/android/hearth-ui/src/main/java/com/enve/hearth/journal/HearthCompletionCenterScreen.kt
@@ -146,6 +146,7 @@ private fun CompletionCoverCard(book: Book, onSelectBook: (Book) -> Unit) {
     ) {
         CoverTile(
             model = book.coverUrl,
+            mediaType = book.mediaType,
             contentDescription = book.title,
             progress = progress,
             modifier = Modifier.fillMaxWidth(),
@@ -183,6 +184,7 @@ private fun CompletionHistoryRow(
     ) {
         CoverTile(
             model = book.coverUrl,
+            mediaType = book.mediaType,
             contentDescription = book.title,
             isFinished = true,
             modifier = Modifier.width(54.dp),

--- a/android/hearth-ui/src/main/java/com/enve/hearth/journal/HearthInsightsScreen.kt
+++ b/android/hearth-ui/src/main/java/com/enve/hearth/journal/HearthInsightsScreen.kt
@@ -158,6 +158,7 @@ private fun TopBooksCard(
             ) {
                 CoverTile(
                     model = entry.book.coverUrl,
+                    mediaType = entry.book.mediaType,
                     contentDescription = entry.book.title,
                     modifier = Modifier.width(42.dp),
                 )

--- a/android/hearth-ui/src/main/java/com/enve/hearth/journal/HearthJournalScreen.kt
+++ b/android/hearth-ui/src/main/java/com/enve/hearth/journal/HearthJournalScreen.kt
@@ -123,7 +123,11 @@ fun HearthJournalScreen(
                         horizontalArrangement = Arrangement.spacedBy(Hearth.Spacing.M),
                     ) {
                         items(mantel, key = { it.id + (it.connectionId ?: "") }) { book ->
-                            CoverTile(model = book.coverUrl, modifier = Modifier.width(112.dp).clickable { onSelectBook(book) })
+                            CoverTile(
+                                model = book.coverUrl,
+                                mediaType = book.mediaType,
+                                modifier = Modifier.width(112.dp).clickable { onSelectBook(book) },
+                            )
                         }
                     }
                 }

--- a/android/hearth-ui/src/main/java/com/enve/hearth/library/HearthLibraryScreen.kt
+++ b/android/hearth-ui/src/main/java/com/enve/hearth/library/HearthLibraryScreen.kt
@@ -1253,6 +1253,7 @@ private fun GridCoverCell(
         ) {
             CoverTile(
                 model = book.coverUrl,
+                mediaType = book.mediaType,
                 modifier = Modifier.fillMaxWidth(),
                 contentDescription = book.title,
                 progress = com.enve.hearth.design.HearthFormat.progress(book),
@@ -1366,6 +1367,7 @@ private fun DenseBookRow(
     ) {
         CoverTile(
             model = book.coverUrl,
+            mediaType = book.mediaType,
             modifier = Modifier.width(44.dp),
             contentDescription = book.title,
             progress = com.enve.hearth.design.HearthFormat.progress(book),

--- a/android/hearth-ui/src/main/java/com/enve/hearth/player/PlayerScreen.kt
+++ b/android/hearth-ui/src/main/java/com/enve/hearth/player/PlayerScreen.kt
@@ -61,6 +61,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.enve.core.data.model.AppMediaType
 import com.enve.hearth.design.CoverTile
 import com.enve.hearth.design.EmberGlow
 import com.enve.hearth.design.Hearth
@@ -157,7 +158,11 @@ fun PlayerScreen(
                 }
 
                 Spacer(Modifier.height(if (compactPanel || widePanel) Hearth.Spacing.S else Hearth.Spacing.L))
-                CoverTile(model = now?.coverUrl, modifier = Modifier.width(coverWidth))
+                CoverTile(
+                    model = now?.coverUrl,
+                    mediaType = AppMediaType.AUDIOBOOK,
+                    modifier = Modifier.width(coverWidth),
+                )
                 Spacer(Modifier.height(coverBottomGap))
 
                 val chapterTitle = chapters.getOrNull(chapterIndex)?.title

--- a/android/hearth-ui/src/main/java/com/enve/hearth/player/PlayerSheets.kt
+++ b/android/hearth-ui/src/main/java/com/enve/hearth/player/PlayerSheets.kt
@@ -108,7 +108,11 @@ private fun QueueSheet(vm: HearthPlayerViewModel, onDismiss: () -> Unit) {
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(Hearth.Spacing.S),
             ) {
-                CoverTile(model = item.book.coverUrl, modifier = Modifier.width(42.dp))
+                CoverTile(
+                    model = item.book.coverUrl,
+                    mediaType = item.book.mediaType,
+                    modifier = Modifier.width(42.dp),
+                )
                 Column(Modifier.weight(1f)) {
                     Text(item.book.title, style = HearthText.Label, color = palette.text, maxLines = 2)
                     item.book.author?.takeIf { it.isNotBlank() }?.let {

--- a/android/hearth-ui/src/main/java/com/enve/hearth/shell/MantelBar.kt
+++ b/android/hearth-ui/src/main/java/com/enve/hearth/shell/MantelBar.kt
@@ -167,6 +167,7 @@ private fun EmberPill(
     val title = book?.title ?: now?.title.orEmpty()
     val author = book?.author ?: now?.author
     val coverUrl = book?.coverUrl ?: now?.coverUrl
+    val mediaType = book?.mediaType ?: now?.let { AppMediaType.AUDIOBOOK }
     val progress = when {
         isEbook -> (book.epubProgress ?: book.readProgress).coerceIn(0f, 1f)
         isActiveAudio -> transport.progress
@@ -179,7 +180,7 @@ private fun EmberPill(
             .padding(Hearth.Spacing.XS),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        PillArtwork(coverUrl, progress)
+        PillArtwork(coverUrl, mediaType, progress)
         Spacer(Modifier.width(Hearth.Spacing.S))
         val line2 = if (isActiveAudio) subtitle ?: author else author
         Column(Modifier.weight(1f)) {
@@ -227,7 +228,7 @@ private fun EmberPill(
 }
 
 @Composable
-private fun PillArtwork(coverUrl: String?, progress: Float) {
+private fun PillArtwork(coverUrl: String?, mediaType: AppMediaType?, progress: Float) {
     val palette = Hearth.palette
     val eink = Hearth.eink
     Box(Modifier.size(46.dp), contentAlignment = Alignment.Center) {
@@ -250,8 +251,13 @@ private fun PillArtwork(coverUrl: String?, progress: Float) {
         val coverShape = RoundedCornerShape(if (eink.sharpCorners) 0.dp else 6.dp)
         Box(
             Modifier
-                .width(28.dp)
-                .height(40.dp)
+                .then(
+                    if (mediaType == AppMediaType.AUDIOBOOK || mediaType == AppMediaType.PODCAST) {
+                        Modifier.size(36.dp)
+                    } else {
+                        Modifier.width(28.dp).height(40.dp)
+                    },
+                )
                 .clip(coverShape)
                 .background(if (eink.active) palette.bgElevated else palette.emberSoft)
                 .then(if (eink.active) Modifier.border(1.dp, palette.text, coverShape) else Modifier),

--- a/android/hearth-ui/src/test/java/com/enve/hearth/design/CoverTileTest.kt
+++ b/android/hearth-ui/src/test/java/com/enve/hearth/design/CoverTileTest.kt
@@ -1,0 +1,20 @@
+package com.enve.hearth.design
+
+import com.enve.core.data.model.AppMediaType
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CoverTileTest {
+
+    @Test
+    fun usesPortraitFramesForEbooksAndFallbackArtwork() {
+        assertEquals(2f / 3f, coverAspectRatio(AppMediaType.EBOOK), 0f)
+        assertEquals(2f / 3f, coverAspectRatio(null), 0f)
+    }
+
+    @Test
+    fun usesSquareFramesForAudioArtwork() {
+        assertEquals(1f, coverAspectRatio(AppMediaType.AUDIOBOOK), 0f)
+        assertEquals(1f, coverAspectRatio(AppMediaType.PODCAST), 0f)
+    }
+}

--- a/android/wear/build.gradle.kts
+++ b/android/wear/build.gradle.kts
@@ -12,8 +12,8 @@ android {
         applicationId = "com.enve.app"
         minSdk = 30
         targetSdk = 36
-        versionCode = 46
-        versionName = "1.2 build 46"
+        versionCode = 50
+        versionName = "1.2 build 50"
     }
 
     buildTypes {

--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.2.2 (1) — 2026-09-08
+
+- Preserve square audiobook artwork across library, player, and queue surfaces.
+- Improve progress reconciliation, pending-write protection, and error reporting across library providers.
+- Correct Plex album grouping and playback URLs, BookOrbit series numbering, and OPDS feed URL handling.
+- Fix CarPlay chapter controls and playback-session lifecycle, and preserve database backups before corruption recovery.
+- Add on-device passage matching for downloaded, linked audiobooks and ebooks on iOS 26 or newer. Older iOS versions show an update-required prompt; the app still supports iOS 17.
+
+Live speech-to-ebook matching remains pending device verification.
+
 ## 1.2 (117) — 2026-07-31
 
 ### Fixed

--- a/ios/RELEASES.md
+++ b/ios/RELEASES.md
@@ -1,12 +1,12 @@
 # Public Release Model
 
-This repository contains stable public source releases of Enve Book Player. Active development takes place in a separate private repository.
+This repository contains public source snapshots of Enve Book Player. Active development takes place in a separate private repository.
 
-Each public update is prepared from a reviewed private release candidate and published as a clean snapshot. The public repository does not mirror private development history, temporary branches, credentials, signing material, unreleased experiments, or internal release notes.
+Each public update is prepared from a reviewed development revision and published as a clean snapshot. The public repository does not mirror private development history, temporary branches, credentials, signing material, or internal release notes. Snapshots may include features ahead of their app-store release; the changelog records known verification limits.
 
 ## What to expect
 
-- `main` represents the latest public source release.
+- `main` represents the latest public source snapshot.
 - Version tags identify the source corresponding to public app releases.
 - Release notes describe user-visible changes and known limitations.
 - Urgent public fixes may land between app releases when needed.

--- a/ios/docs/architecture/provider-capability-matrix.md
+++ b/ios/docs/architecture/provider-capability-matrix.md
@@ -55,12 +55,12 @@ Legend: ✓ supported, ✗ not supported, ⚠ partial / capped (note in §3 belo
 
 | Provider | full | paged | stream | delta | recent | series | coll. | absPull | absPush | epubPull | epubPush | dl | covH | covQ | pgStream | bg |
 |---|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
-| Audiobookshelf | ✓ | ⚠¹ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ |
-| Plex            | ✓ | ✓ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ |
-| Jellyfin        | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ |
+| Audiobookshelf | ✓ | ⚠¹ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ |
+| Plex            | ✓ | ✓ | ✗ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✓ |
+| Jellyfin        | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ | ✓ |
 | Emby            | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✗ | ✗ | ✓ |
-| Komga           | ✓ | ⚠¹ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ |
-| Kavita          | ✓ | ⚠¹ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ |
+| Komga           | ✓ | ⚠¹ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ |
+| Kavita          | ✓ | ⚠¹ | ✗ | ✗ | ✓ | ✗ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ |
 | Booklore        | ✓ | ✓ | ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ |
 | BookOrbit       | ✓ | ✓ | ✗ | ✗ | ✗³ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ |
 | Silo            | ✓ | ✓ | ✓ | ✗ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✗ | ✓ |
@@ -80,14 +80,14 @@ Columns: **full** = fullImport, **paged** = pagedImport, **stream** = streamingI
 
 ## Per-provider notes
 
-- **Audiobookshelf** — reference provider for streaming through `fetchBookBatches`. Cover auth uses a `?token=` query item. No ebook progress push today.
-- **Plex** — paged via `X-Plex-Container-Start/Size`. Series and collections are inferred from paths. Progress push uses `:/scrobble`; progress pull is unavailable.
-- **Jellyfin** / **Emby** — server-paged via `StartIndex` / `Limit`. Cover URLs require `X-Emby-Token` headers and must use the authenticated cover loader.
+- **Audiobookshelf** — reference provider for streaming through `fetchBookBatches`. Cover auth uses a `?token=` query item. Ebook updates submit `ebookProgress` without audio time or duration fields. Audio updates include the full book duration and omit `isFinished: false` for nonzero playback positions because ABS otherwise resets the position when reopening a finished item.
+- **Plex** — paged via `X-Plex-Container-Start/Size`. Series and collections are inferred from paths. Progress pushes use `:/timeline`; progress pulls combine track offsets into the book timeline.
+- **Jellyfin** / **Emby** — server-paged via `StartIndex` / `Limit`. Cover URLs require `X-Emby-Token` headers and must use the authenticated cover loader. Audio positions are saved through user-data updates. Neither provider advertises native ebook-position sync: Jellyfin accepts but does not persist `PlayedPercentage` for ebooks. Ebook download/reading remains available.
 - **Komga** — comic-server: only provider with `serverPageStreaming` today. Delta uses `sort=created,desc`. Cover URL uses HTTP Basic — fine for the iOS `URLSession` cover loader but not for `AsyncImage` without a header rewrite.
-- **Kavita** — POST-paginated (body, not query). JWT cover auth via Bearer header. No series exposed (returns `[]`).
+- **Kavita** — POST requests use one-based query pagination and a library-filter statement in the JSON body. JWT cover auth via Bearer header. No series exposed (returns `[]`). Ebook progress uses the same first chapter as the downloaded ebook and the native Reader progress endpoints.
 - **Booklore** — three-tier (app-tier `/api/v1/app/*`, legacy REST `/api/v1/rest/*`, Komga fallback). Carries both header and query auth for covers. Full progress matrix.
 - **BookOrbit** — JWT (15-min access / 7-day refresh httpOnly cookie). Header-only auth. Catalog import stays pagination-only for compatibility with releases that reject `filter`/`sort`; activity sync behaviorally probes the newer paginated `readStatus` filter and falls back to the bounded dashboard endpoint when unavailable. Collections support complete definition and membership snapshots. No universally available sort or recent-books endpoint exists across supported releases.
-- **Silo** — profile-scoped API with snapshot-fenced catalog pagination and cursor-based progress sync. Collections include complete personal/manual/smart definitions and memberships plus visible server library collections.
+- **Silo** — profile-scoped API with snapshot-fenced catalog pagination and cursor-based progress sync. Ebook resets and rereads clear the server’s latched watched state before applying a new position. Collections include complete personal/manual/smart definitions and memberships plus visible server library collections.
 - **OPDS** — read-only feed (Atom 1.x + OPDS 2.0 JSON); depth-bounded traversal. Auth via challenge-response delegate (Basic/Digest/Bearer). No structured series/collections — OPDS spec doesn't expose them.
 - **Storyteller** — covers carry both Bearer header AND a `?w=` query sizing token. Full progress matrix incl. read-aloud (EPUB3 SMIL).
 - **WebDAV** — file-system enumeration via PROPFIND. No progress, covers, series, or collections. Directory traversal is not currently depth-bounded.
@@ -101,3 +101,13 @@ Columns: **full** = fullImport, **paged** = pagedImport, **stream** = streamingI
 4. Cross-check against the per-provider notes in §"Per-provider notes" — those describe *why* the flags are what they are; if your change invalidates a note, edit it.
 
 The capability surface is intentionally honest: a missing flag (✗) signals real work to do, not a TODO to be silenced by adding it.
+
+## Progress refresh
+
+Audiobookshelf reconciliation is scoped to its connection and processes the returned progress records, including completed and reset items. Jellyfin, Emby, Plex and Kavita use their native provider progress capabilities; they never receive Audiobookshelf requests. Manual refresh visits all indexed books for those connections, while startup limits per-book requests to 40 recent local books. Providers without a batch progress endpoint require per-book requests, so manual reconciliation can take longer on large libraries.
+
+Booklore, BookOrbit, Komga, Silo and Storyteller retain their dedicated strategies. Manual Booklore and Silo ebook refresh is no longer limited to a recent window or a cross-connection candidate cap. Provider strategy failures propagate to the refresh result. Pending local writes are protected during reconciliation.
+
+Emby ebooks and file-only sources do not advertise service progress sync. Emby audiobook progress is supported. OPDS, WebDAV, debrid and local files have no native service progress endpoint; their Enve/iCloud progress is separate. Booklore legacy REST and Komga fallback tiers report unsupported ebook uploads instead of reporting a successful write.
+
+Komga resets use its documented [mark book as unread](https://komga.org/docs/openapi/delete-book-read-progress/) endpoint rather than writing page one.

--- a/ios/enve.xcodeproj/project.pbxproj
+++ b/ios/enve.xcodeproj/project.pbxproj
@@ -314,6 +314,7 @@
 				Screens/Player/PlayerChapterRibbon.swift,
 				Screens/Player/PlayerClipSheets.swift,
 				Screens/Player/PlayerListSheets.swift,
+				Screens/Player/PlayerPassageSheet.swift,
 				Screens/Player/PlayerQueueSheet.swift,
 				Screens/Player/PlayerScreen.swift,
 				Screens/Player/PlayerSheets.swift,
@@ -418,6 +419,7 @@
 				Services/StoryAlign/StoryAlignService.swift,
 				Services/StoryAlign/StorytellerReadaloudOfflinePrep.swift,
 				Services/StoryAlign/TokenSearchAlgorithm.swift,
+				Services/Sync/LinkedBookPassageService.swift,
 				Services/Sync/LinkedBookQuickSyncService.swift,
 				Services/System/ShakeDetectionService.swift,
 				Services/System/SleepDataService.swift,
@@ -1167,7 +1169,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = enve/Configuration/enve.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 119;
+				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = 9TT6DBK8W3;
 				ENABLE_APP_SANDBOX = YES;
@@ -1199,7 +1201,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.1;
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.enve.enve;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -1224,7 +1226,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = enve/enveRelease.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 119;
+				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = 9TT6DBK8W3;
 				ENABLE_APP_SANDBOX = YES;
@@ -1257,7 +1259,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.1;
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.enve.enve;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -1280,12 +1282,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 119;
+				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MACOSX_DEPLOYMENT_TARGET = 26.1;
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.enve.enveTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -1308,12 +1310,12 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 119;
+				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MACOSX_DEPLOYMENT_TARGET = 26.1;
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.enve.enveTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -1335,11 +1337,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MACOSX_DEPLOYMENT_TARGET = 26.1;
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.enve.enveUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -1359,12 +1362,12 @@
 		1D03D1182F1629110008FD58 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CURRENT_PROJECT_VERSION = 119;
+				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MACOSX_DEPLOYMENT_TARGET = 26.1;
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.enve.enveUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -1388,7 +1391,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "enve-tvOS/EnveTV.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 119;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 9TT6DBK8W3;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1401,7 +1404,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.enve.enve;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
@@ -1423,7 +1426,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "enve-tvOS/EnveTVRelease.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 119;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 9TT6DBK8W3;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1436,7 +1439,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.enve.enve;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
@@ -1459,7 +1462,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = EnveWatch/EnveWatch.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 119;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 9TT6DBK8W3;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1471,7 +1474,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.enve.enve.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -1494,7 +1497,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = EnveWatch/EnveWatch.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 119;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 9TT6DBK8W3;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1506,7 +1509,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.enve.enve.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -1529,7 +1532,7 @@
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_ENTITLEMENTS = EnveBookWidgets/EnveBookWidgets.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 119;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 9TT6DBK8W3;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = EnveBookWidgets/Info.plist;
@@ -1539,7 +1542,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.enve.enve.widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1558,7 +1561,7 @@
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_ENTITLEMENTS = EnveBookWidgets/EnveBookWidgets.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 119;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 9TT6DBK8W3;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = EnveBookWidgets/Info.plist;
@@ -1568,7 +1571,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.enve.enve.widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/ios/enve/App/EnveApp.swift
+++ b/ios/enve/App/EnveApp.swift
@@ -45,6 +45,20 @@ struct EnveApp: App {
         registry.register(libraryProviderFactory: { BookOrbitProvider(connection: $0) }, for: .bookOrbit)
         registry.register(libraryProviderFactory: { SiloProvider(connection: $0) }, for: .silo)
 
+        let nativeProgressSources: [(ProviderType, Book.BookSource)] = [
+            (.jellyfin, .jellyfin), (.emby, .emby), (.plex, .plex), (.kavita, .kavita),
+        ]
+        for (type, source) in nativeProgressSources {
+            registry.register(
+                syncStrategy: NativeProgressSyncStrategy(
+                    providerType: type, source: source,
+                    connections: providerConnections, books: bookStore,
+                    progressRepository: bookStore, libraryCache: AppState.shared,
+                    progressCache: BookProgressStore.shared, playbackState: ActivePlayback.controller
+                )
+            )
+        }
+
         registry.register(
             syncStrategy: StorytellerSyncStrategy(
                 providerConnections: providerConnections,

--- a/ios/enve/App/MantelBar.swift
+++ b/ios/enve/App/MantelBar.swift
@@ -220,6 +220,7 @@ struct MantelBar: View {
 
     private func emberPill(book: Book) -> some View {
         let live = isLive(book)
+        let artworkWidth = 42 / book.hearthCoverRatio
         return HStack(spacing: 8) {
             Button {
                 if book.mediaType == .ebook && !book.hasEPUB3MediaOverlay {
@@ -238,7 +239,7 @@ struct MantelBar: View {
                         book: book
                     )
                     .aspectRatio(contentMode: .fill)
-                    .frame(width: 42, height: 42)
+                    .frame(width: artworkWidth, height: 42)
                     .clipShape(RoundedRectangle(cornerRadius: 9, style: .continuous))
                     .overlay {
                         RoundedRectangle(cornerRadius: 9, style: .continuous)
@@ -256,6 +257,7 @@ struct MantelBar: View {
                     .task(id: book.stableId) {
                         pillTint = await AmbientColorStore.shared.resolve(for: book)
                     }
+                    .frame(width: 42, height: 42)
 
                     VStack(alignment: .leading) {
                         HearthMarqueeText(

--- a/ios/enve/CarPlay/CarPlayChapters.swift
+++ b/ios/enve/CarPlay/CarPlayChapters.swift
@@ -29,7 +29,11 @@ final class CarPlayChapters {
 
         let section = CPListSection(items: items)
         let listTemplate = CPListTemplate(title: "Chapters", sections: [section])
-        interfaceController.pushTemplate(listTemplate, animated: true, completion: nil)
+        interfaceController.pushTemplate(
+            listTemplate,
+            animated: true,
+            completion: carPlayInterfaceCompletion("Show chapters")
+        )
     }
 
     private func createListItem(for chapter: Chapter, number: Int, isCurrent: Bool) -> CPListItem {
@@ -44,16 +48,22 @@ final class CarPlayChapters {
         item.isPlaying = isCurrent
 
         item.handler = { [weak self] _, completion in
-            self?.onChapterSelected(chapter)
-            completion()
+            guard let self else {
+                completion()
+                return
+            }
+            self.onChapterSelected(chapter, completion: completion)
         }
 
         return item
     }
 
-    private func onChapterSelected(_ chapter: Chapter) {
+    private func onChapterSelected(_ chapter: Chapter, completion: @escaping () -> Void) {
         playback.seek(to: chapter.start)
-        interfaceController.popTemplate(animated: true, completion: nil)
+        interfaceController.popTemplate(
+            animated: true,
+            completion: carPlayInterfaceCompletion("Close chapters", then: completion)
+        )
     }
 
     private func formatDuration(_ duration: TimeInterval) -> String {

--- a/ios/enve/CarPlay/CarPlayController.swift
+++ b/ios/enve/CarPlay/CarPlayController.swift
@@ -1,6 +1,7 @@
 @preconcurrency import CarPlay
 import Combine
 import Foundation
+import Logging
 
 final class CarPlayController {
     private let interfaceController: CPInterfaceController
@@ -40,6 +41,23 @@ final class CarPlayController {
                 nowPlaying.showNowPlaying()
             }
         }
+    }
+}
+
+@MainActor
+func carPlayInterfaceCompletion(
+    _ operation: String,
+    then followUp: (() -> Void)? = nil
+) -> (Bool, (any Error)?) -> Void {
+    { success, error in
+        if !success {
+            if let error {
+                AppLogger.carplay.error("[CarPlay] \(operation) failed: \(error)")
+            } else {
+                AppLogger.carplay.error("[CarPlay] \(operation) failed")
+            }
+        }
+        followUp?()
     }
 }
 

--- a/ios/enve/CarPlay/CarPlayNowPlaying.swift
+++ b/ios/enve/CarPlay/CarPlayNowPlaying.swift
@@ -119,13 +119,22 @@ final class CarPlayNowPlaying {
 
     private func presentPlaybackError(_ message: String) {
         guard isConnected else { return }
+        guard interfaceController.presentedTemplate == nil else { return }
         AppLogger.carplay.error("[CarPlay] Playback error: \(message)")
 
         let dismiss = CPAlertAction(title: "OK", style: .default) { [weak self] _ in
-            self?.interfaceController.dismissTemplate(animated: true, completion: nil)
+            guard let self, self.interfaceController.presentedTemplate != nil else { return }
+            self.interfaceController.dismissTemplate(
+                animated: true,
+                completion: carPlayInterfaceCompletion("Dismiss playback error")
+            )
         }
         let alert = CPAlertTemplate(titleVariants: [message], actions: [dismiss])
-        interfaceController.presentTemplate(alert, animated: true, completion: nil)
+        interfaceController.presentTemplate(
+            alert,
+            animated: true,
+            completion: carPlayInterfaceCompletion("Present playback error")
+        )
     }
 
     private func updateNowPlayingTemplate() {
@@ -201,17 +210,27 @@ final class CarPlayNowPlaying {
             let item = CPListItem(text: label, detailText: nil)
             item.isPlaying = isSelected
             item.handler = { [weak self] _, completion in
+                guard let self else {
+                    completion()
+                    return
+                }
                 AppLogger.carplay.info("[CarPlay] Setting new speed: \(speed)x")
-                self?.controller.setPlaybackRate(Double(speed))
-                self?.interfaceController.popTemplate(animated: true, completion: nil)
-                completion()
+                self.controller.setPlaybackRate(Double(speed))
+                self.interfaceController.popTemplate(
+                    animated: true,
+                    completion: carPlayInterfaceCompletion("Close playback speed", then: completion)
+                )
             }
             return item
         }
 
         let section = CPListSection(items: items)
         let listTemplate = CPListTemplate(title: "Playback Speed", sections: [section])
-        interfaceController.pushTemplate(listTemplate, animated: true, completion: nil)
+        interfaceController.pushTemplate(
+            listTemplate,
+            animated: true,
+            completion: carPlayInterfaceCompletion("Show playback speed")
+        )
     }
 
     private func onChaptersTapped(chapters resolvedChapters: [Chapter]) {

--- a/ios/enve/CarPlay/CarPlayTabBar.swift
+++ b/ios/enve/CarPlay/CarPlayTabBar.swift
@@ -89,7 +89,11 @@ final class CarPlayTabBar: NSObject {
         }
 
         tabBarTemplate = newTemplate
-        interfaceController.setRootTemplate(newTemplate, animated: false, completion: nil)
+        interfaceController.setRootTemplate(
+            newTemplate,
+            animated: false,
+            completion: carPlayInterfaceCompletion("Set root template")
+        )
     }
 
     private func refreshVisibleTabs() {

--- a/ios/enve/Models/Providers/Audiobookshelf/AudiobookshelfModels.swift
+++ b/ios/enve/Models/Providers/Audiobookshelf/AudiobookshelfModels.swift
@@ -474,6 +474,14 @@ public struct ABSMediaProgress: Codable {
     public var progressPercentage: Double {
         return (progress ?? 0) * 100
     }
+
+    public var resolvedIsFinished: Bool {
+        if isFinished == true || finishedAt != nil || (progress ?? 0) >= 0.99 {
+            return true
+        }
+        guard let duration, duration > 0, let currentTime else { return false }
+        return currentTime >= duration * 0.99
+    }
 }
 
 public struct ABSPlaySessionRequest: Codable {

--- a/ios/enve/Networking/LibraryProvider.swift
+++ b/ios/enve/Networking/LibraryProvider.swift
@@ -1,6 +1,17 @@
 import CryptoKit
 import Foundation
 
+enum ProviderProgressDate {
+    static func parse(_ value: String?) -> Date? {
+        guard let value else { return nil }
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = formatter.date(from: value) { return date }
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: value)
+    }
+}
+
 struct PlaybackSessionInfo {
     let sessionId: String
     let audioTracks: [AudioTrackInfo]

--- a/ios/enve/Networking/Providers/AudiobookshelfProvider.swift
+++ b/ios/enve/Networking/Providers/AudiobookshelfProvider.swift
@@ -34,7 +34,7 @@ enum ABSMediaTypeClassifier {
 }
 
 class AudiobookshelfProvider: IncrementalCatalogProvider, PlaybackSessionProvider, AudiobookProgressProvider,
-    EbookProgressPulling, EbookDownloadProvider, @unchecked Sendable
+    EbookProgressProvider, EbookDownloadProvider, @unchecked Sendable
 {
     var connection: ServerConnection
 
@@ -42,7 +42,7 @@ class AudiobookshelfProvider: IncrementalCatalogProvider, PlaybackSessionProvide
         [
             .fullImport, .pagedImport, .streamingImport, .deltaImport,
             .recentBooks, .series, .collections,
-            .audiobookProgressPull, .audiobookProgressPush, .ebookProgressPull,
+            .audiobookProgressPull, .audiobookProgressPush, .ebookProgressPull, .ebookProgressPush,
             .downloads, .coverAuthQuery, .backgroundOperation,
         ]
     }
@@ -633,6 +633,14 @@ class AudiobookshelfProvider: IncrementalCatalogProvider, PlaybackSessionProvide
         let lastUpdate: Double?
         let ebookProgress: Double?
         let ebookLocation: String?
+
+        var resolvedIsFinished: Bool {
+            if isFinished == true || (progress ?? 0) >= 0.99 {
+                return true
+            }
+            guard let duration, duration > 0, let currentTime else { return false }
+            return currentTime >= duration * 0.99
+        }
     }
 
     func fetchLibraries() async throws -> [Library] {
@@ -1489,7 +1497,7 @@ class AudiobookshelfProvider: IncrementalCatalogProvider, PlaybackSessionProvide
                     episodeId: item.episodeId,
                     currentTime: item.currentTime ?? 0,
                     progress: item.progress ?? 0,
-                    isFinished: item.isFinished ?? false,
+                    isFinished: item.resolvedIsFinished,
                     duration: item.duration ?? 0,
                     lastUpdate: item.lastUpdateDate ?? Date.distantPast,
                     ebookProgress: item.ebookProgress
@@ -1554,7 +1562,7 @@ class AudiobookshelfProvider: IncrementalCatalogProvider, PlaybackSessionProvide
                 episodeId: p.episodeId,
                 currentTime: p.currentTime ?? 0,
                 progress: p.progress ?? 0,
-                isFinished: p.isFinished ?? false,
+                isFinished: p.resolvedIsFinished,
                 duration: p.duration ?? 0,
                 lastUpdate: p.lastUpdate.map { Date(timeIntervalSince1970: $0 / 1000) } ?? Date.distantPast,
                 ebookProgress: p.ebookProgress
@@ -1880,12 +1888,14 @@ class AudiobookshelfProvider: IncrementalCatalogProvider, PlaybackSessionProvide
             progressRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
             let duration = book.duration ?? 0
-            let progressBody: [String: Any] = [
+            var progressBody: [String: Any] = [
                 "currentTime": currentTime,
-                "isFinished": isFinished,
+                "duration": duration,
                 "progress": currentTime / (duration > 0 ? duration : 1),
             ]
-            progressRequest.httpBody = try? JSONSerialization.data(withJSONObject: progressBody)
+            // ABS clears currentTime when isFinished changes from true to false.
+            if isFinished || currentTime <= 0 { progressBody["isFinished"] = isFinished }
+            progressRequest.httpBody = try JSONSerialization.data(withJSONObject: progressBody)
 
             let (_, progressResponse) = try await performRequest(progressRequest)
             guard let progressHttp = progressResponse as? HTTPURLResponse, (200...299).contains(progressHttp.statusCode) else {
@@ -1906,12 +1916,13 @@ class AudiobookshelfProvider: IncrementalCatalogProvider, PlaybackSessionProvide
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
             let duration = book.duration ?? 0
-            let body: [String: Any] = [
+            var body: [String: Any] = [
                 "currentTime": currentTime,
-                "isFinished": isFinished,
+                "duration": duration,
                 "progress": currentTime / (duration > 0 ? duration : 1),
             ]
-            request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+            if isFinished || currentTime <= 0 { body["isFinished"] = isFinished }
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
             let (_, response) = try await performRequest(request)
             guard let httpResponse = response as? HTTPURLResponse, (200...299).contains(httpResponse.statusCode) else {
@@ -2158,17 +2169,14 @@ class AudiobookshelfProvider: IncrementalCatalogProvider, PlaybackSessionProvide
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
         var body: [String: Any] = [
-            "progress": progress,
             "ebookProgress": progress,
-            "currentTime": 0,
-            "duration": 0,
             "isFinished": progress >= 0.99,
         ]
         if let epubLocator {
             body["ebookLocation"] = epubLocator
         }
 
-        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
         let (_, response) = try await performRequest(request)
         if let httpResponse = response as? HTTPURLResponse, !(200...299).contains(httpResponse.statusCode) {
@@ -2188,13 +2196,11 @@ class AudiobookshelfProvider: IncrementalCatalogProvider, PlaybackSessionProvide
         var request = URLRequest(url: progressURL)
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
 
-        guard let (data, response) = try? await performRequest(request),
-            let http = response as? HTTPURLResponse,
-            http.statusCode == 200,
-            let p = try? Self.absDecoder.decode(ABSProgressItem.self, from: data)
-        else {
-            return nil
-        }
+        let (data, response) = try await performRequest(request)
+        guard let http = response as? HTTPURLResponse else { throw ProviderError.invalidResponse }
+        if http.statusCode == 404 { return nil }
+        guard http.statusCode == 200 else { throw ProviderError.invalidResponse }
+        let p = try Self.absDecoder.decode(ABSProgressItem.self, from: data)
 
         let progress = p.ebookProgress ?? p.progress ?? 0
         let locator = p.ebookLocation
@@ -2211,17 +2217,17 @@ class AudiobookshelfProvider: IncrementalCatalogProvider, PlaybackSessionProvide
             throw ProviderError.unauthorized
         }
 
-        let progressURL = baseURL.appendingPathComponent("api/me/progress/\(book.partKey ?? book.id)")
+        var path = "api/me/progress/\(book.podcastLibraryItemId ?? book.partKey ?? book.id)"
+        if book.isPodcastEpisode, let episodeId = book.episodeId { path += "/\(episodeId)" }
+        let progressURL = baseURL.appendingPathComponent(path)
         var request = URLRequest(url: progressURL)
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
 
-        guard let (data, response) = try? await performRequest(request),
-            let http = response as? HTTPURLResponse,
-            http.statusCode == 200,
-            let p = try? Self.absDecoder.decode(ABSProgressItem.self, from: data)
-        else {
-            return nil
-        }
+        let (data, response) = try await performRequest(request)
+        guard let http = response as? HTTPURLResponse else { throw ProviderError.invalidResponse }
+        if http.statusCode == 404 { return nil }
+        guard http.statusCode == 200 else { throw ProviderError.invalidResponse }
+        let p = try Self.absDecoder.decode(ABSProgressItem.self, from: data)
 
         let positionSeconds = p.currentTime ?? 0
         let percentage = p.progress ?? 0

--- a/ios/enve/Networking/Providers/BookOrbitProvider.swift
+++ b/ios/enve/Networking/Providers/BookOrbitProvider.swift
@@ -11,6 +11,7 @@ final class BookOrbitProvider: IncrementalCatalogProvider, PlaybackSessionProvid
     @unchecked Sendable
 {
     var connection: ServerConnection
+    private let session: URLSession?
     private var cachedContinueProgress: [UserMediaProgress] = []
     private var cachedContinueProgressAt: Date = .distantPast
     private var cachedAdminStatus: Bool?
@@ -112,8 +113,9 @@ final class BookOrbitProvider: IncrementalCatalogProvider, PlaybackSessionProvid
         cachedContinueProgressAt = .distantPast
     }
 
-    init(connection: ServerConnection) {
+    init(connection: ServerConnection, session: URLSession? = nil) {
         self.connection = connection
+        self.session = session
     }
 
     private var refreshTokenKey: String { "bookorbit_refresh_\(connection.id.uuidString)" }
@@ -185,7 +187,7 @@ final class BookOrbitProvider: IncrementalCatalogProvider, PlaybackSessionProvid
         applyCustomHeaders(&request)
         request.httpBody = try JSONSerialization.data(withJSONObject: ["username": username, "password": password])
 
-        let (data, response) = try await InsecureURLSession.shared.data(for: request)
+        let (data, response) = try await (session ?? InsecureURLSession.shared).data(for: request)
         guard let http = response as? HTTPURLResponse else { throw ProviderError.invalidResponse }
         guard http.statusCode == 200 else {
             if http.statusCode == 401 { throw ProviderError.unauthorized }
@@ -222,7 +224,7 @@ final class BookOrbitProvider: IncrementalCatalogProvider, PlaybackSessionProvid
         request.setValue("refresh_token=\(refresh)", forHTTPHeaderField: "Cookie")
         applyCustomHeaders(&request)
 
-        let (data, response) = try await InsecureURLSession.shared.data(for: request)
+        let (data, response) = try await (session ?? InsecureURLSession.shared).data(for: request)
         guard let http = response as? HTTPURLResponse, http.statusCode == 200,
             let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
             let accessToken = json["accessToken"] as? String, !accessToken.isEmpty
@@ -458,7 +460,7 @@ final class BookOrbitProvider: IncrementalCatalogProvider, PlaybackSessionProvid
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         }
 
-        let (data, response) = try await InsecureURLSession.shared.data(for: request)
+        let (data, response) = try await (session ?? InsecureURLSession.shared).data(for: request)
         guard let http = response as? HTTPURLResponse else { throw ProviderError.invalidResponse }
         return (data, http)
     }
@@ -486,6 +488,19 @@ final class BookOrbitProvider: IncrementalCatalogProvider, PlaybackSessionProvid
 
     private struct BooksPageDTO: Decodable { let items: [BookCardDTO]; let total: Int; let page: Int; let size: Int }
 
+    private struct SeriesIndex: Decodable, Sendable {
+        let value: String
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            if let text = try? container.decode(String.self) {
+                value = text
+            } else {
+                value = try container.decode(Decimal.self).description
+            }
+        }
+    }
+
     private struct BookCardDTO: Decodable, Sendable {
         let id: Int
         let title: String?
@@ -493,7 +508,7 @@ final class BookOrbitProvider: IncrementalCatalogProvider, PlaybackSessionProvid
         let authors: [String]?
         let narrators: [String]?
         let seriesName: String?
-        let seriesIndex: Double?
+        let seriesIndex: SeriesIndex?
         let publishedYear: Int?
         let language: String?
         let genres: [String]?
@@ -527,7 +542,7 @@ final class BookOrbitProvider: IncrementalCatalogProvider, PlaybackSessionProvid
         let publishedYear: Int?
         let language: String?
         let seriesName: String?
-        let seriesIndex: Double?
+        let seriesIndex: SeriesIndex?
         let authors: [AuthorDTO]?
         let genres: [String]?
         let rating: Double?
@@ -1158,7 +1173,7 @@ final class BookOrbitProvider: IncrementalCatalogProvider, PlaybackSessionProvid
             title: dto.title ?? "Untitled",
             author: dto.authors?.joined(separator: ", "),
             narrator: dto.narrators?.joined(separator: ", "),
-            seriesInfo: dto.seriesName.map { SeriesInfo(name: $0, sequence: dto.seriesIndex.map(Self.sequenceString)) },
+            seriesInfo: dto.seriesName.map { SeriesInfo(name: $0, sequence: dto.seriesIndex?.value) },
             duration: nil,
             coverURL: coverURL,
             partKey: String(dto.id),
@@ -1217,7 +1232,7 @@ final class BookOrbitProvider: IncrementalCatalogProvider, PlaybackSessionProvid
             title: dto.title ?? "Untitled",
             author: dto.authors?.map { $0.name }.joined(separator: ", "),
             narrator: narrator,
-            seriesInfo: dto.seriesName.map { SeriesInfo(name: $0, sequence: dto.seriesIndex.map(Self.sequenceString)) },
+            seriesInfo: dto.seriesName.map { SeriesInfo(name: $0, sequence: dto.seriesIndex?.value) },
             duration: isAudiobook ? totalDuration : nil,
             coverURL: coverURL,
             partKey: String(dto.id),
@@ -1259,6 +1274,7 @@ final class BookOrbitProvider: IncrementalCatalogProvider, PlaybackSessionProvid
             let dur = durations ? (file.durationSeconds ?? 0) : 0
             tracks.append(
                 AudioTrack(
+                    id: String(file.id),
                     index: index,
                     title: file.filename,
                     filePath: String(file.id),
@@ -1282,10 +1298,6 @@ final class BookOrbitProvider: IncrementalCatalogProvider, PlaybackSessionProvid
             let end = index + 1 < sorted.count ? sorted[index + 1].startMs / 1000.0 : max(start, totalDuration)
             return Chapter(id: String(index), start: start, end: end, title: ch.title, index: index)
         }
-    }
-
-    private static func sequenceString(_ value: Double) -> String {
-        value.rounded() == value ? String(Int(value)) : String(value)
     }
 
     func getAudioURL(for book: Book) -> URL? {
@@ -1322,6 +1334,7 @@ final class BookOrbitProvider: IncrementalCatalogProvider, PlaybackSessionProvid
             }
             infos.append(
                 AudioTrackInfo(
+                    id: track.filePath ?? track.id,
                     index: index,
                     startOffset: offset,
                     duration: duration,
@@ -1370,14 +1383,11 @@ final class BookOrbitProvider: IncrementalCatalogProvider, PlaybackSessionProvid
         isFinished: Bool,
         timeListened: TimeInterval
     ) async throws {
-        guard let bookId = Int(book.id) else { return }
+        guard let bookId = Int(book.id) else { throw ProviderError.invalidResponse }
 
         let (fileId, localPosition) = currentFileAndOffset(book: book, globalPosition: currentTime)
         guard let fileId else {
-            AppLogger.sync.debug(
-                "[BookOrbit] No file to attribute progress bookId=\(DiagnosticLogSanitizer.identifier(for: book.stableId)); skipping"
-            )
-            return
+            throw ProviderError.invalidResponse
         }
 
         let duration = book.duration ?? 0
@@ -1656,18 +1666,16 @@ final class BookOrbitProvider: IncrementalCatalogProvider, PlaybackSessionProvid
     func fetchAudiobookProgress(
         for book: Book
     ) async throws -> (positionSeconds: TimeInterval, percentage: Double, trackIndex: Int?, updatedAt: Date?, isAbandoned: Bool)? {
-        guard let bookId = Int(book.id) else { return nil }
-        guard let (data, http) = try? await perform("books/\(bookId)/audio-progress"),
-            http.statusCode == 200, !data.isEmpty,
-            let dto = try? Self.decoder.decode(AudioProgressDTO.self, from: data),
-            let fileId = dto.currentFileId
-        else {
-            return nil
-        }
+        guard let bookId = Int(book.id) else { throw ProviderError.invalidResponse }
+        let (data, http) = try await perform("books/\(bookId)/audio-progress")
+        if http.statusCode == 404 || http.statusCode == 204 { return nil }
+        guard http.statusCode == 200 else { throw ProviderError.invalidResponse }
+        guard let dto = try Self.decoder.decode(AudioProgressDTO?.self, from: data) else { return nil }
+        guard let fileId = dto.currentFileId else { return nil }
 
         let local = dto.positionSeconds ?? 0
         let tracks = await tracksForOffsetMapping(book: book)
-        let track = tracks.first { Int($0.filePath ?? "") == fileId }
+        let track = tracks.first { Int($0.filePath ?? $0.id) == fileId }
         let global = (track?.startOffset ?? 0) + local
         let percentage = (dto.percentage ?? 0) / 100.0
         return (
@@ -1679,7 +1687,7 @@ final class BookOrbitProvider: IncrementalCatalogProvider, PlaybackSessionProvid
     private func currentFileAndOffset(book: Book, globalPosition: TimeInterval) -> (fileId: Int?, offset: TimeInterval) {
         if let tracks = book.audioTracks, !tracks.isEmpty {
             let track = tracks.last { $0.startOffset <= globalPosition } ?? tracks.first
-            let fileId = track.flatMap { Int($0.filePath ?? "") }
+            let fileId = track.flatMap { Int($0.filePath ?? $0.id) }
             let offset = globalPosition - (track?.startOffset ?? 0)
             return (fileId, offset)
         }
@@ -1766,13 +1774,11 @@ final class BookOrbitProvider: IncrementalCatalogProvider, PlaybackSessionProvid
     }
 
     func fetchEbookProgress(for book: Book) async throws -> (progress: Double, locator: String?, updatedAt: Date?, isAbandoned: Bool)? {
-        guard let ino = book.audioFileIno, let fileId = Int(ino) else { return nil }
-        guard let (data, http) = try? await perform("books/files/\(fileId)/progress"),
-            http.statusCode == 200,
-            let dto = try? Self.decoder.decode(FileProgressDTO.self, from: data)
-        else {
-            return nil
-        }
+        guard let ino = book.audioFileIno, let fileId = Int(ino) else { throw ProviderError.invalidResponse }
+        let (data, http) = try await perform("books/files/\(fileId)/progress")
+        if http.statusCode == 404 || http.statusCode == 204 { return nil }
+        guard http.statusCode == 200 else { throw ProviderError.invalidResponse }
+        guard let dto = try Self.decoder.decode(FileProgressDTO?.self, from: data) else { return nil }
         let progress = (dto.percentage ?? 0) / 100.0
         return (progress: progress, locator: dto.cfi, updatedAt: dto.updatedAt, isAbandoned: progress >= 0.99)
     }

--- a/ios/enve/Networking/Providers/BookloreProvider.swift
+++ b/ios/enve/Networking/Providers/BookloreProvider.swift
@@ -3622,7 +3622,7 @@ class BookloreProvider: LibraryProvider, PlaybackSessionProvider, AudiobookProgr
             AppLogger.network.debug(
                 "[Booklore] Ebook progress push unsupported for active API tier bookDiagnosticID=\(DiagnosticLogSanitizer.identifier(for: book.stableId))"
             )
-            return
+            throw ProviderError.notImplemented
         }
 
         if book.epub3Features?.hasMediaOverlay == true {
@@ -3635,7 +3635,7 @@ class BookloreProvider: LibraryProvider, PlaybackSessionProvider, AudiobookProgr
             AppLogger.network.error(
                 "[Booklore] Ebook progress push skipped; invalid bookDiagnosticID=\(DiagnosticLogSanitizer.identifier(for: book.stableId))"
             )
-            return
+            throw ProviderError.invalidResponse
         }
 
         let resource = try await resolveGrimmoryEPUBResource(for: book)

--- a/ios/enve/Networking/Providers/EmbyProvider.swift
+++ b/ios/enve/Networking/Providers/EmbyProvider.swift
@@ -958,10 +958,10 @@ class EmbyProvider: IncrementalCatalogProvider, PlaybackSessionProvider, Audiobo
         isFinished: Bool,
         timeListened: TimeInterval
     ) async throws {
-        guard let userId = connection.userId else { return }
+        guard let userId = connection.userId else { throw ProviderError.unauthorized }
         let base = EmbyProvider.normalizeServerURL(connection.url)
 
-        guard let url = URL(string: "\(base)/Users/\(userId)/Items/\(book.id)/UserData") else { return }
+        guard let url = URL(string: "\(base)/Users/\(userId)/Items/\(book.id)/UserData") else { throw ProviderError.invalidURL }
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
@@ -972,11 +972,15 @@ class EmbyProvider: IncrementalCatalogProvider, PlaybackSessionProvider, Audiobo
         let body: [String: Any] = [
             "PlaybackPositionTicks": ticks,
             "Played": isFinished,
+            "LastPlayedDate": ISO8601DateFormatter().string(from: Date()),
         ]
 
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
-        _ = try await session.data(for: request)
+        let (_, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
+            throw ProviderError.invalidResponse
+        }
     }
 
     func getAudioURL(for book: Book) -> URL? {
@@ -992,23 +996,22 @@ class EmbyProvider: IncrementalCatalogProvider, PlaybackSessionProvider, Audiobo
     func fetchAudiobookProgress(
         for book: Book
     ) async throws -> (positionSeconds: TimeInterval, percentage: Double, trackIndex: Int?, updatedAt: Date?, isAbandoned: Bool)? {
-        guard let userId = connection.userId else { return nil }
+        guard let userId = connection.userId else { throw ProviderError.unauthorized }
         let base = EmbyProvider.normalizeServerURL(connection.url)
 
-        guard let url = URL(string: "\(base)/Users/\(userId)/Items/\(book.id)?Fields=UserData") else { return nil }
+        guard let url = URL(string: "\(base)/Users/\(userId)/Items/\(book.id)?Fields=UserData") else { throw ProviderError.invalidURL }
         var request = URLRequest(url: url)
         addAuthHeaders(&request)
 
-        guard let (data, response) = try? await session.data(for: request),
-            let http = response as? HTTPURLResponse, http.statusCode == 200,
-            let item = try? JSONDecoder().decode(EmbyItem.self, from: data)
-        else {
-            return nil
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+            throw ProviderError.invalidResponse
         }
+        let item = try JSONDecoder().decode(EmbyItem.self, from: data)
 
         let positionSeconds = Double(item.UserData?.PlaybackPositionTicks ?? 0) / 10_000_000.0
         let played = item.UserData?.Played ?? false
-        return (positionSeconds: positionSeconds, percentage: 0, trackIndex: nil, updatedAt: nil, isAbandoned: played)
+        return (positionSeconds: positionSeconds, percentage: 0, trackIndex: nil, updatedAt: ProviderProgressDate.parse(item.UserData?.LastPlayedDate), isAbandoned: played)
     }
 
     func fetchCollections(libraryId: String?) async throws -> [Collection] { return [] }
@@ -1286,6 +1289,7 @@ private struct EmbyChapter: Decodable {
 }
 
 private struct EmbyUserData: Decodable {
+    let LastPlayedDate: String?
     let PlaybackPositionTicks: Int64?
     let Played: Bool?
     let PlayedPercentage: Double?

--- a/ios/enve/Networking/Providers/JellyfinProvider.swift
+++ b/ios/enve/Networking/Providers/JellyfinProvider.swift
@@ -8,7 +8,7 @@ import UIKit
 #endif
 
 class JellyfinProvider: IncrementalCatalogProvider, PlaybackSessionProvider, AudiobookProgressProvider,
-    EbookProgressProvider, EbookDownloadProvider, ObservableObject, @unchecked Sendable
+    EbookDownloadProvider, ObservableObject, @unchecked Sendable
 {
     @Published var connection: ServerConnection
     let session: URLSession
@@ -17,7 +17,6 @@ class JellyfinProvider: IncrementalCatalogProvider, PlaybackSessionProvider, Aud
         [
             .fullImport, .pagedImport,
             .audiobookProgressPull, .audiobookProgressPush,
-            .ebookProgressPull, .ebookProgressPush,
             .downloads, .coverAuthHeader, .backgroundOperation,
         ]
     }
@@ -127,7 +126,7 @@ class JellyfinProvider: IncrementalCatalogProvider, PlaybackSessionProvider, Aud
         }
 
         AppLogger.network.info("[JellyfinProvider] No valid token, checking for username/password...")
-        guard let username = connection.username, let password = connection.token else {
+        guard let username = connection.username, let password = connection.password ?? connection.token else {
             AppLogger.network.warning("[JellyfinProvider] Missing username or password")
             return false
         }
@@ -173,7 +172,6 @@ class JellyfinProvider: IncrementalCatalogProvider, PlaybackSessionProvider, Aud
 
     private func authenticate(username: String, password: String) async throws {
         AppLogger.network.info("[JellyfinProvider] ===== AUTHENTICATION STARTED =====")
-        AppLogger.network.info("[JellyfinProvider] Username: \(username)")
 
         let base = normalizeServerURL(connection.url)
         AppLogger.network.info("[JellyfinProvider] Server URL: \(URL(string: base)?.redacted.absoluteString ?? "<invalid>")")
@@ -446,32 +444,7 @@ class JellyfinProvider: IncrementalCatalogProvider, PlaybackSessionProvider, Aud
         var book = mapJellyfinItemToBook(item, libraryId: libraryId, base: base)
         book.chapters = chapters
 
-        if duration != book.duration {
-            AppLogger.network.info("Recreating book with corrected duration: \(duration)s")
-            let newProgress = duration > 0 ? (book.currentTime / duration) : 0
-            book = Book(
-                id: book.id,
-                title: book.title,
-                author: book.author,
-                narrator: book.narrator,
-                seriesInfo: book.seriesInfo,
-                duration: duration,
-                coverURL: book.coverURL,
-                dateAdded: book.dateAdded,
-                releaseDate: book.releaseDate,
-                description: book.description,
-                genres: book.genres,
-                chapters: book.chapters,
-                publisher: book.publisher,
-                progress: newProgress,
-                currentTime: book.currentTime,
-                isFinished: book.isFinished,
-                lastUpdate: book.lastUpdate,
-                libraryId: book.libraryId,
-                providerId: book.providerId,
-                rawMetadata: book.rawMetadata
-            )
-        }
+        book.duration = duration
         return book
     }
 
@@ -548,31 +521,27 @@ class JellyfinProvider: IncrementalCatalogProvider, PlaybackSessionProvider, Aud
         isFinished: Bool,
         timeListened: TimeInterval
     ) async throws {
-        guard let userId = connection.userId, let _ = connection.token else { return }
+        guard let userId = connection.userId, connection.token != nil else { throw ProviderError.unauthorized }
         let base = normalizeServerURL(connection.url)
-        let positionTicks = Int64(currentTime * 10_000_000)
-
-        guard let url = URL(string: "\(base)/Users/\(userId)/PlayingItems/\(book.id)/Progress?PositionTicks=\(positionTicks)") else {
-            return
+        guard let url = URL(string: "\(base)/Users/\(userId)/Items/\(book.id)/UserData") else {
+            throw ProviderError.invalidURL
         }
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         addAuthHeaders(&request)
-
-        _ = try? await performDataTask(for: request)
-
-        if isFinished {
-            guard let playedUrl = URL(string: "\(base)/Users/\(userId)/PlayedItems/\(book.id)") else {
-                return
-            }
-            var playedRequest = URLRequest(url: playedUrl)
-            playedRequest.httpMethod = "POST"
-            addAuthHeaders(&playedRequest)
-            _ = try? await performDataTask(for: playedRequest)
+        request.httpBody = try JSONSerialization.data(withJSONObject: [
+            "PlaybackPositionTicks": Int64(max(0, currentTime) * 10_000_000),
+            "Played": isFinished,
+            "LastPlayedDate": ISO8601DateFormatter().string(from: Date()),
+        ])
+        let (_, response) = try await performDataTask(for: request)
+        guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
+            throw ProviderError.invalidResponse
         }
     }
 
-    private func performDataTask(for request: URLRequest, retryCount: Int = 3) async throws -> (Data, URLResponse) {
+    func performDataTask(for request: URLRequest, retryCount: Int = 3) async throws -> (Data, URLResponse) {
         var currentRetry = 0
         while true {
             do {
@@ -603,6 +572,15 @@ class JellyfinProvider: IncrementalCatalogProvider, PlaybackSessionProvider, Aud
     private func fetchChildAudioItems(parentId: String) async throws -> [JellyfinItem] {
         guard let userId = connection.userId else { return [] }
         let base = normalizeServerURL(connection.url)
+
+        guard let parentURL = URL(string: "\(base)/Users/\(userId)/Items/\(parentId)") else { throw ProviderError.invalidURL }
+        var parentRequest = URLRequest(url: parentURL)
+        addAuthHeaders(&parentRequest)
+        let (parentData, parentResponse) = try await performDataTask(for: parentRequest)
+        guard let http = parentResponse as? HTTPURLResponse, http.statusCode == 200 else { throw ProviderError.invalidResponse }
+        let parent = try JSONDecoder().decode(JellyfinItem.self, from: parentData)
+        // Jellyfin treats a non-folder ParentId as the user's library root.
+        guard parent.IsFolder == true else { return [] }
 
         guard var components = URLComponents(string: "\(base)/Users/\(userId)/Items") else { return [] }
         components.queryItems = [
@@ -780,74 +758,26 @@ class JellyfinProvider: IncrementalCatalogProvider, PlaybackSessionProvider, Aud
         )
     }
 
-    func updateEbookProgress(for book: Book, progress: Double, epubLocator: String?) async throws {
-        guard let userId = connection.userId else { throw ProviderError.unauthorized }
-        let base = normalizeServerURL(connection.url)
-
-        guard let url = URL(string: "\(base)/Users/\(userId)/Items/\(book.id)/UserData") else { return }
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        addAuthHeaders(&request)
-
-        let body: [String: Any] = [
-            "PlayedPercentage": max(0, min(100, progress * 100)),
-            "Played": progress >= 0.99,
-        ]
-        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
-        _ = try? await performDataTask(for: request)
-
-        if progress >= 0.99,
-            let playedURL = URL(string: "\(base)/Users/\(userId)/PlayedItems/\(book.id)")
-        {
-            var playedRequest = URLRequest(url: playedURL)
-            playedRequest.httpMethod = "POST"
-            addAuthHeaders(&playedRequest)
-            _ = try? await performDataTask(for: playedRequest)
-        }
-    }
-
-    func fetchEbookProgress(for book: Book) async throws -> (progress: Double, locator: String?, updatedAt: Date?, isAbandoned: Bool)? {
-        guard let userId = connection.userId else { return nil }
-        let base = normalizeServerURL(connection.url)
-
-        guard let url = URL(string: "\(base)/Users/\(userId)/Items/\(book.id)?Fields=UserData") else { return nil }
-        var request = URLRequest(url: url)
-        addAuthHeaders(&request)
-
-        guard let (data, response) = try? await performDataTask(for: request),
-            let http = response as? HTTPURLResponse, http.statusCode == 200,
-            let item = try? JSONDecoder().decode(JellyfinItem.self, from: data)
-        else {
-            return nil
-        }
-
-        let percentage = (item.UserData?.PlayedPercentage ?? 0) / 100.0
-        let played = item.UserData?.Played ?? false
-        return (progress: percentage, locator: nil, updatedAt: nil, isAbandoned: played)
-    }
-
     func fetchAudiobookProgress(
         for book: Book
     ) async throws -> (positionSeconds: TimeInterval, percentage: Double, trackIndex: Int?, updatedAt: Date?, isAbandoned: Bool)? {
-        guard let userId = connection.userId else { return nil }
+        guard let userId = connection.userId else { throw ProviderError.unauthorized }
         let base = normalizeServerURL(connection.url)
 
-        guard let url = URL(string: "\(base)/Users/\(userId)/Items/\(book.id)?Fields=UserData") else { return nil }
+        guard let url = URL(string: "\(base)/Users/\(userId)/Items/\(book.id)?Fields=UserData") else { throw ProviderError.invalidURL }
         var request = URLRequest(url: url)
         addAuthHeaders(&request)
 
-        guard let (data, response) = try? await performDataTask(for: request),
-            let http = response as? HTTPURLResponse, http.statusCode == 200,
-            let item = try? JSONDecoder().decode(JellyfinItem.self, from: data)
-        else {
-            return nil
+        let (data, response) = try await performDataTask(for: request)
+        guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+            throw ProviderError.invalidResponse
         }
+        let item = try JSONDecoder().decode(JellyfinItem.self, from: data)
 
         let positionSeconds = Double(item.UserData?.PlaybackPositionTicks ?? 0) / 10_000_000.0
         let percentage = (item.UserData?.PlayedPercentage ?? 0) / 100.0
         let played = item.UserData?.Played ?? false
-        return (positionSeconds: positionSeconds, percentage: percentage, trackIndex: nil, updatedAt: nil, isAbandoned: played)
+        return (positionSeconds: positionSeconds, percentage: percentage, trackIndex: nil, updatedAt: ProviderProgressDate.parse(item.UserData?.LastPlayedDate), isAbandoned: played)
     }
 }
 
@@ -877,12 +807,13 @@ private struct JellyfinItem: Decodable {
     let Studios: [JellyfinNameIdPair]?
     let Genres: [String]?
     let ChildCount: Int?
+    let IsFolder: Bool?
     let MediaSources: [JellyfinMediaSource]?
 
     enum CodingKeys: String, CodingKey {
         case Id, ParentId, Name, MediaType, CollectionType, RunTimeTicks, ProductionYear, Overview
         case AlbumArtist, AlbumArtists, ArtistItems, ImageTags, Chapters, UserData
-        case SeriesName, IndexNumber, Studios, Genres, ChildCount, MediaSources
+        case SeriesName, IndexNumber, Studios, Genres, ChildCount, IsFolder, MediaSources
         case itemType = "Type"
     }
 }
@@ -900,6 +831,7 @@ private struct JellyfinChapter: Decodable {
 }
 
 private struct JellyfinUserData: Decodable {
+    let LastPlayedDate: String?
     let PlaybackPositionTicks: Int64?
     let Played: Bool?
     let PlayedPercentage: Double?

--- a/ios/enve/Networking/Providers/KavitaProvider.swift
+++ b/ios/enve/Networking/Providers/KavitaProvider.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Logging
 
-class KavitaProvider: IncrementalCatalogProvider, EbookProgressPushing, EbookDownloadProvider,
+class KavitaProvider: IncrementalCatalogProvider, EbookProgressProvider, EbookDownloadProvider,
     @unchecked Sendable
 {
     var connection: ServerConnection
@@ -10,14 +10,13 @@ class KavitaProvider: IncrementalCatalogProvider, EbookProgressPushing, EbookDow
         [
             .fullImport, .pagedImport,
             .recentBooks, .collections,
-            .ebookProgressPush,
+            .ebookProgressPull, .ebookProgressPush,
             .downloads, .coverAuthHeader, .backgroundOperation,
         ]
     }
 
     private let pageSize = 100
     private var jwtToken: String?
-    private var pageCountCache: [String: Int] = [:]
 
     init(connection: ServerConnection) {
         self.connection = connection
@@ -81,12 +80,14 @@ class KavitaProvider: IncrementalCatalogProvider, EbookProgressPushing, EbookDow
     private func fetchCatalogPage(libraryId: String, page: Int) async throws -> LibraryCatalogPage {
         guard let libraryId = Int(libraryId) else { throw ProviderError.invalidResponse }
         let body: [String: Any] = [
-            "libraryIds": [libraryId],
-            "pageNumber": page,
-            "pageSize": pageSize,
+            "statements": [["field": 19, "comparison": 0, "value": String(libraryId)]],
+            "combination": 0,
             "sortOptions": ["sortField": 5, "isAscending": false],
         ]
-        var request = try makeRequest(path: "/api/Series/v2")
+        var request = try makeRequest(path: "/api/Series/v2", queryItems: [
+            URLQueryItem(name: "pageNumber", value: String(page + 1)),
+            URLQueryItem(name: "pageSize", value: String(pageSize)),
+        ])
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
@@ -104,13 +105,23 @@ class KavitaProvider: IncrementalCatalogProvider, EbookProgressPushing, EbookDow
 
     func fetchRecentBooks(libraryId: String, limit: Int) async throws -> [Book] {
         try await ensureAuthenticated()
-        let request = try makeRequest(path: "/api/Series/recently-added-v2")
+        guard let libraryId = Int(libraryId) else { throw ProviderError.invalidResponse }
+        var request = try makeRequest(path: "/api/Series/recently-added-v2", queryItems: [
+            URLQueryItem(name: "pageNumber", value: "1"),
+            URLQueryItem(name: "pageSize", value: String(max(1, limit))),
+        ])
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: [
+            "statements": [["field": 19, "comparison": 0, "value": String(libraryId)]],
+            "combination": 0,
+        ])
         let (data, response) = try await send(request)
         guard response.statusCode == 200 else {
-            return []
+            throw ProviderError.serverError("Failed to fetch recent series (HTTP \(response.statusCode))")
         }
         let result = try JSONDecoder().decode([KavitaSeries].self, from: data)
-        return Array(result.prefix(limit).map { mapToBook($0, libraryId: libraryId) })
+        return Array(result.prefix(limit).map { mapToBook($0, libraryId: String(libraryId)) })
     }
 
     func fetchCollections(libraryId: String?) async throws -> [Collection] {
@@ -235,12 +246,14 @@ class KavitaProvider: IncrementalCatalogProvider, EbookProgressPushing, EbookDow
     }
 
     func updateEbookProgress(for book: Book, progress: Double, epubLocator: String?) async throws {
-        try await ensureAuthenticated()
-        guard let seriesId = Int(book.id) else { return }
-        let totalPages = try await resolvePageCount(for: book)
+        let (volume, chapter) = try await readingChapter(for: book)
+        guard let seriesId = Int(book.id), let libraryId = Int(book.libraryId) else { throw ProviderError.invalidResponse }
         let body: [String: Any] = [
             "seriesId": seriesId,
-            "pagesRead": max(1, Int(progress * Double(totalPages))),
+            "libraryId": libraryId,
+            "volumeId": volume.id,
+            "chapterId": chapter.id,
+            "pageNum": Int(max(0, min(1, progress)) * Double(chapter.pages)),
         ]
         var request = try makeRequest(path: "/api/Reader/progress")
         request.httpMethod = "POST"
@@ -252,22 +265,32 @@ class KavitaProvider: IncrementalCatalogProvider, EbookProgressPushing, EbookDow
         }
     }
 
-    private func resolvePageCount(for book: Book) async throws -> Int {
-        if let cached = pageCountCache[book.id] { return cached }
-        guard let seriesId = Int(book.id) else {
-            throw ProviderError.serverError("Invalid series ID for Kavita page count")
-        }
-        let request = try makeRequest(path: "/api/Series/\(seriesId)")
+    func fetchEbookProgress(for book: Book) async throws -> (progress: Double, locator: String?, updatedAt: Date?, isAbandoned: Bool)? {
+        let (_, chapter) = try await readingChapter(for: book)
+        let request = try makeRequest(path: "/api/Reader/get-progress?chapterId=\(chapter.id)")
         let (data, response) = try await send(request)
         guard response.statusCode == 200 else {
-            throw ProviderError.serverError("Could not fetch Kavita page count (HTTP \(response.statusCode))")
+            throw ProviderError.serverError("Failed to fetch Kavita progress (HTTP \(response.statusCode))")
         }
-        let detail = try JSONDecoder().decode(KavitaSeriesPageInfo.self, from: data)
-        guard detail.pages > 0 else {
-            throw ProviderError.serverError("Kavita returned zero pages for series \(seriesId)")
+        let progress = try JSONDecoder().decode(KavitaReadingProgress.self, from: data)
+        let fraction = max(0, min(1, Double(progress.pageNum) / Double(chapter.pages)))
+        return (progress: fraction, locator: nil, updatedAt: ProviderProgressDate.parse(progress.lastModifiedUtc), isAbandoned: false)
+    }
+
+    private func readingChapter(for book: Book) async throws -> (KavitaVolume, KavitaChapter) {
+        try await ensureAuthenticated()
+        guard let seriesId = Int(book.id) else { throw ProviderError.invalidResponse }
+        let request = try makeRequest(path: "/api/Series/volumes?seriesId=\(seriesId)")
+        let (data, response) = try await send(request)
+        guard response.statusCode == 200 else {
+            throw ProviderError.serverError("Failed to fetch Kavita volumes (HTTP \(response.statusCode))")
         }
-        pageCountCache[book.id] = detail.pages
-        return detail.pages
+        let volumes = try JSONDecoder().decode([KavitaVolume].self, from: data)
+        // Downloads currently open the first chapter of the first volume.
+        guard let volume = volumes.first, let chapter = volume.chapters?.first, chapter.pages > 0 else {
+            throw ProviderError.invalidResponse
+        }
+        return (volume, chapter)
     }
 
     func ensureAuthenticated() async throws {
@@ -435,10 +458,6 @@ class KavitaProvider: IncrementalCatalogProvider, EbookProgressPushing, EbookDow
         let summary: String?
     }
 
-    private struct KavitaSeriesPageInfo: Decodable {
-        let pages: Int
-    }
-
     private struct KavitaVolume: Decodable {
         let id: Int
         let chapters: [KavitaChapter]?
@@ -447,6 +466,12 @@ class KavitaProvider: IncrementalCatalogProvider, EbookProgressPushing, EbookDow
     private struct KavitaChapter: Decodable {
         let id: Int
         let title: String?
+        let pages: Int
+    }
+
+    private struct KavitaReadingProgress: Decodable {
+        let pageNum: Int
+        let lastModifiedUtc: String?
     }
 
     private struct KavitaCollectionTag: Decodable {

--- a/ios/enve/Networking/Providers/KomgaProvider.swift
+++ b/ios/enve/Networking/Providers/KomgaProvider.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Logging
 
-class KomgaProvider: IncrementalCatalogProvider, EbookProgressPushing, EbookDownloadProvider,
+class KomgaProvider: IncrementalCatalogProvider, EbookProgressProvider, EbookDownloadProvider,
     ServerPageProvider, @unchecked Sendable
 {
     var connection: ServerConnection
@@ -348,6 +348,15 @@ class KomgaProvider: IncrementalCatalogProvider, EbookProgressPushing, EbookDown
     }
 
     func updateEbookProgress(for book: Book, progress: Double, epubLocator: String?) async throws {
+        if progress <= 0 {
+            var request = try makeRequest(path: "/api/v1/books/\(book.id)/read-progress")
+            request.httpMethod = "DELETE"
+            let (_, response) = try await send(request)
+            guard (200...299).contains(response.statusCode) else {
+                throw ProviderError.serverError("Failed to reset Komga progress (HTTP \(response.statusCode))")
+            }
+            return
+        }
         let totalPages = try await fetchPageCount(for: book)
         guard totalPages > 0 else {
             throw ProviderError.serverError("Komga returned zero pages for book \(book.id)")

--- a/ios/enve/Networking/Providers/OPDSProvider.swift
+++ b/ios/enve/Networking/Providers/OPDSProvider.swift
@@ -373,9 +373,8 @@ class OPDSProvider: WholeSnapshotCatalogProvider, EbookDownloadProvider, @unchec
         return preview.contains("\"metadata\"") || preview.contains("\"publications\"")
     }
 
-    private func feedURL() -> URL {
+    func feedURL() -> URL {
         var str = connection.url.trimmingCharacters(in: .whitespacesAndNewlines)
-        while str.hasSuffix("/") { str.removeLast() }
         if !str.hasPrefix("http") { str = "http://\(str)" }
         return URL(string: str) ?? URL(string: "http://invalid")!
     }

--- a/ios/enve/Networking/Providers/PlexProvider.swift
+++ b/ios/enve/Networking/Providers/PlexProvider.swift
@@ -35,7 +35,7 @@ func resolvePlexProgressTarget(book: Book, currentTime: TimeInterval) -> PlexPro
     )
 }
 
-class PlexProvider: IncrementalCatalogProvider, PlaybackSessionProvider, AudiobookProgressPushing,
+class PlexProvider: IncrementalCatalogProvider, PlaybackSessionProvider, AudiobookProgressProvider,
     @unchecked Sendable
 {
     var connection: ServerConnection
@@ -44,7 +44,7 @@ class PlexProvider: IncrementalCatalogProvider, PlaybackSessionProvider, Audiobo
         [
             .fullImport, .pagedImport,
             .recentBooks,
-            .audiobookProgressPush,
+            .audiobookProgressPull, .audiobookProgressPush,
             .downloads, .coverAuthQuery, .backgroundOperation,
         ]
     }
@@ -109,8 +109,8 @@ class PlexProvider: IncrementalCatalogProvider, PlaybackSessionProvider, Audiobo
         }
     }
 
-    private func trackTimeline(from tracks: [PlexMetadata]) -> PlexTrackTimeline {
-        let sorted = orderedTracks(tracks)
+    private func trackTimeline(from tracks: [PlexMetadata], preserveOrder: Bool = false) -> PlexTrackTimeline {
+        let sorted = preserveOrder ? tracks : orderedTracks(tracks)
         var audioTracks: [AudioTrack] = []
         var chapters: [Chapter] = []
         var offset: TimeInterval = 0
@@ -344,6 +344,16 @@ class PlexProvider: IncrementalCatalogProvider, PlaybackSessionProvider, Audiobo
         let key: String
         let title: String
         let type: String
+        var location: [Location]? = nil
+
+        struct Location: Codable {
+            let path: String
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case key, title, type
+            case location = "Location"
+        }
     }
 
     fileprivate struct PlexItemsResponse: Codable {
@@ -358,7 +368,7 @@ class PlexProvider: IncrementalCatalogProvider, PlaybackSessionProvider, Audiobo
         }
     }
 
-    fileprivate struct PlexMetadata: Codable {
+    struct PlexMetadata: Codable {
         let ratingKey: String
         let key: String
         let parentRatingKey: String?
@@ -388,7 +398,7 @@ class PlexProvider: IncrementalCatalogProvider, PlaybackSessionProvider, Audiobo
         }
     }
 
-    fileprivate struct PlexMedia: Codable {
+    struct PlexMedia: Codable {
         let duration: Double?
         let container: String?
         let audioCodec: String?
@@ -400,7 +410,7 @@ class PlexProvider: IncrementalCatalogProvider, PlaybackSessionProvider, Audiobo
         }
     }
 
-    fileprivate struct PlexPart: Codable {
+    struct PlexPart: Codable {
         let id: Int?
         let key: String
         let duration: Double?
@@ -552,7 +562,7 @@ class PlexProvider: IncrementalCatalogProvider, PlaybackSessionProvider, Audiobo
         guard parsed else {
             throw ProviderError.invalidResponse
         }
-        return delegate.sections.map { PlexSection(key: $0.key, title: $0.title, type: $0.type) }
+        return delegate.sections.map { PlexSection(key: $0.key, title: $0.title, type: $0.type, location: $0.paths.map { PlexSection.Location(path: $0) }) }
     }
 
     func fetchBooks(libraryId: String) async throws -> [Book] {
@@ -765,7 +775,7 @@ class PlexProvider: IncrementalCatalogProvider, PlaybackSessionProvider, Audiobo
         books.removeAll { $0.title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
         return LibraryCatalogPage(
             books: books,
-            totalCount: response.totalSize,
+            totalCount: nil,
             isLast: response.metadata.count < pageSize
                 || response.totalSize.map { offset + response.metadata.count >= $0 } == true
         )
@@ -974,26 +984,98 @@ class PlexProvider: IncrementalCatalogProvider, PlaybackSessionProvider, Audiobo
             let trackContainer = try decodeItemsContainer(from: trackData)
             let tracks = orderedTracks(trackContainer.metadata ?? [])
 
-            guard !tracks.isEmpty else {
-                return [mapPlexMetadataToBook(album, libraryId: libraryId)]
+            var roots: [String] = []
+            if Self.isUnknownAlbumTitle(album.title) {
+                let request = try buildRequest(path: "library/sections")
+                let (data, _) = try await performDataTask(for: request)
+                roots = try decodeLibrarySections(from: data).first { $0.key == libraryId }?.location?.map(\.path) ?? []
             }
-
-            let timeline = trackTimeline(from: tracks)
-            return [
-                mapPlexMetadataToBook(
-                    album,
-                    libraryId: libraryId,
-                    overrideDuration: timeline.duration,
-                    partKey: timeline.partKey,
-                    audioTracks: timeline.audioTracks,
-                    chapters: timeline.chapters
-                )
-            ]
+            var books = mapPlexAlbum(album, tracks: tracks, libraryId: libraryId, libraryRoots: roots)
+            if books.count > 1,
+                let existing = await AppState.shared.bookStore.book(uniqueId: "\(connection.id.uuidString)_\(album.ratingKey)") {
+                let bookmarks = await AppState.shared.bookStore.bookmarks(forBookStableId: existing.stableId)
+                let downloaded = await MainActor.run { LocalStorageManager.shared.isAudiobookDownloaded(existing.downloadKey) }
+                if Self.shouldPreserveAlbum(existing, hasBookmarks: !bookmarks.isEmpty, isDownloaded: downloaded) {
+                    books = [existing]
+                }
+            }
+            return books
         } catch {
             AppLogger.network.error(
                 "Failed to fetch tracks albumDiagnosticID=\(DiagnosticLogSanitizer.identifier(for: album.title)); using single item"
             )
             return [mapPlexMetadataToBook(album, libraryId: libraryId)]
+        }
+    }
+
+    static func isUnknownAlbumTitle(_ title: String) -> Bool {
+        let title = title.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return title.isEmpty || title == "[unknown album]" || title == "unknown album"
+            || title.hasPrefix("unknown album (") || title.hasPrefix("[unknown album] (")
+    }
+
+    static func shouldPreserveAlbum(_ book: Book, hasBookmarks: Bool, isDownloaded: Bool) -> Bool {
+        book.currentTime > 0 || book.isFinished || hasBookmarks || isDownloaded
+    }
+
+    func mapPlexAlbum(_ album: PlexMetadata, tracks: [PlexMetadata], libraryId: String, libraryRoots: [String] = []) -> [Book] {
+        guard !tracks.isEmpty else { return [mapPlexMetadataToBook(album, libraryId: libraryId)] }
+        let sorted = orderedTracks(tracks)
+        guard Self.isUnknownAlbumTitle(album.title), !libraryRoots.isEmpty,
+            sorted.allSatisfy({ $0.media?.first?.part?.first?.file?.isEmpty == false }) else {
+            let timeline = trackTimeline(from: sorted)
+            return [mapPlexMetadataToBook(album, libraryId: libraryId, overrideDuration: timeline.duration,
+                partKey: timeline.partKey, audioTracks: timeline.audioTracks, chapters: timeline.chapters)]
+        }
+
+        let roots = Set(libraryRoots.map { URL(fileURLWithPath: $0).standardizedFileURL.path })
+        func bookFolder(_ track: PlexMetadata) -> URL? {
+            guard let path = track.media?.first?.part?.first?.file else { return nil }
+            var folder = URL(fileURLWithPath: path).standardizedFileURL.deletingLastPathComponent()
+            if folder.lastPathComponent.range(of: #"(?i)^(?:cd|disc|disk)[ ._-]*[0-9]+$"#, options: .regularExpression) != nil,
+                !roots.contains(folder.path) {
+                folder.deleteLastPathComponent()
+            }
+            return folder
+        }
+        let groups = Dictionary(grouping: sorted) { track -> String in
+            guard let folder = bookFolder(track),
+                roots.contains(where: { folder.path.hasPrefix($0 + "/") }) else {
+                return "track:\(track.ratingKey)"
+            }
+            return "folder:\(folder.path)"
+        }
+        return groups.values.sorted { $0[0].ratingKey < $1[0].ratingKey }.map { group in
+            let tracks = group.sorted { lhs, rhs in
+                let left = lhs.media?.first?.part?.first?.file ?? lhs.ratingKey
+                let right = rhs.media?.first?.part?.first?.file ?? rhs.ratingKey
+                if URL(fileURLWithPath: left).deletingLastPathComponent() == URL(fileURLWithPath: right).deletingLastPathComponent(),
+                    let leftIndex = lhs.index, let rightIndex = rhs.index, leftIndex != rightIndex {
+                    return leftIndex < rightIndex
+                }
+                return left.localizedStandardCompare(right) == .orderedAscending
+            }
+            let first = tracks[0]
+            if tracks.count == 1, groups.count > 1 { return mapTrackBookToFullBook(first, libraryId: libraryId) }
+            let timeline = trackTimeline(from: tracks, preserveOrder: true)
+            var book = mapPlexMetadataToBook(album, libraryId: libraryId, overrideID: groups.count > 1 ? first.ratingKey : nil, overrideDuration: timeline.duration,
+                partKey: timeline.partKey, audioTracks: timeline.audioTracks, chapters: timeline.chapters)
+            if let path = first.media?.first?.part?.first?.file {
+                let file = URL(fileURLWithPath: path)
+                let folder = file.deletingLastPathComponent()
+                let parent = bookFolder(first) ?? folder
+                if parent != folder {
+                    let discs = Set(tracks.compactMap { $0.media?.first?.part?.first?.file }.map {
+                        URL(fileURLWithPath: $0).deletingLastPathComponent().lastPathComponent
+                    })
+                    book.title = discs.count == 1 ? "\(parent.lastPathComponent) — \(folder.lastPathComponent)" : parent.lastPathComponent
+                } else if tracks.count > 1 || file.deletingPathExtension().lastPathComponent.range(of: #"(?i)^(?:(?:part|chapter|track)[ ._-]*)?[0-9]+$"#, options: .regularExpression) != nil && !roots.contains(folder.path) {
+                    book.title = parent.lastPathComponent
+                } else {
+                    book.title = file.deletingPathExtension().lastPathComponent
+                }
+            }
+            return book
         }
     }
 
@@ -1144,7 +1226,7 @@ class PlexProvider: IncrementalCatalogProvider, PlaybackSessionProvider, Audiobo
             ? [Chapter(id: "full_book", start: 0, end: safeDuration, title: item.title)]
             : normalizedChapters
 
-        return mapPlexMetadataToBook(
+        var book = mapPlexMetadataToBook(
             item,
             libraryId: libraryId,
             overrideDuration: safeDuration,
@@ -1152,6 +1234,10 @@ class PlexProvider: IncrementalCatalogProvider, PlaybackSessionProvider, Audiobo
             audioTracks: timeline.audioTracks,
             chapters: fallbackChapters
         )
+        if Self.isUnknownAlbumTitle(item.title), let existingBook {
+            book.title = existingBook.title
+        }
+        return book
     }
 
     private func fetchEmbeddedChapters(bookId: String, bookDuration: Double?) async throws -> [Chapter] {
@@ -1307,13 +1393,19 @@ class PlexProvider: IncrementalCatalogProvider, PlaybackSessionProvider, Audiobo
         ]
 
         let author = track.grandparentTitle ?? track.parentTitle ?? "Unknown Author"
-        let bookTitle = track.title
+        let bookTitle: String
+        if Self.isUnknownAlbumTitle(track.parentTitle ?? ""),
+            let file = track.media?.first?.part?.first?.file {
+            bookTitle = URL(fileURLWithPath: file).deletingPathExtension().lastPathComponent
+        } else {
+            bookTitle = track.title
+        }
 
         let narrator = extractNarrator(from: track, author: author)
         var seriesInfo = extractSeriesInfo(from: track, author: author)
         if seriesInfo == nil,
             let parentTitle = track.parentTitle,
-            !parentTitle.isEmpty,
+            !Self.isUnknownAlbumTitle(parentTitle),
             parentTitle != track.title,
             parentTitle.lowercased() != author.lowercased()
         {
@@ -1339,7 +1431,7 @@ class PlexProvider: IncrementalCatalogProvider, PlaybackSessionProvider, Audiobo
             chapters: chapters,
             publisher: nil,
             currentTime: (track.viewOffset ?? 0) / 1000.0,
-            isFinished: false,
+            isFinished: (track.viewCount ?? 0) > 0 && (track.viewOffset ?? 0) <= 0,
             lastUpdate: Date(),
             libraryId: libraryId,
             providerId: connection.id,
@@ -1438,15 +1530,22 @@ class PlexProvider: IncrementalCatalogProvider, PlaybackSessionProvider, Audiobo
             AppLogger.network.debug(
                 "Starting multi-album playback bookDiagnosticID=\(DiagnosticLogSanitizer.identifier(for: book.stableId)) tracks=\(storedTracks.count)"
             )
-            for track in storedTracks {
-                guard let partKey = track.contentUrl else { continue }
-                guard var components = URLComponents(url: baseURL.appendingPathComponent(partKey), resolvingAgainstBaseURL: false) else {
-                    continue
+            var partKeys: [String: String] = [:]
+            for start in stride(from: 0, to: storedTracks.count, by: 100) {
+                let ids = storedTracks[start..<min(start + 100, storedTracks.count)].map(\.id).joined(separator: ",")
+                let request = try buildRequest(path: "library/metadata/\(ids)")
+                let (data, response) = try await performDataTask(for: request)
+                guard (response as? HTTPURLResponse)?.statusCode == 200 else {
+                    throw ProviderError.invalidResponse
                 }
-                components.queryItems = [
-                    URLQueryItem(name: "X-Plex-Token", value: token),
-                    URLQueryItem(name: "download", value: "1"),
-                ]
+                for item in try decodeItemsContainer(from: data).metadata ?? [] {
+                    partKeys[item.ratingKey] = item.media?.first?.part?.first?.key
+                }
+            }
+            for track in storedTracks {
+                guard let partKey = partKeys[track.id], let url = buildStreamingURL(partKey: partKey) else {
+                    throw ProviderError.invalidResponse
+                }
 
                 audioTracks.append(
                     AudioTrackInfo(
@@ -1454,7 +1553,7 @@ class PlexProvider: IncrementalCatalogProvider, PlaybackSessionProvider, Audiobo
                         index: track.index,
                         startOffset: track.startOffset,
                         duration: track.duration,
-                        contentUrl: components.url?.absoluteString ?? partKey,
+                        contentUrl: url.absoluteString,
                         mimeType: track.format ?? "application/octet-stream",
                         title: track.title
                     )
@@ -1556,22 +1655,34 @@ class PlexProvider: IncrementalCatalogProvider, PlaybackSessionProvider, Audiobo
     func fetchAudiobookProgress(
         for book: Book
     ) async throws -> (positionSeconds: TimeInterval, percentage: Double, trackIndex: Int?, updatedAt: Date?, isAbandoned: Bool)? {
-        let request = try buildRequest(path: "library/metadata/\(book.id)")
-        let (data, response) = try await performDataTask(for: request)
-        guard let http = response as? HTTPURLResponse, http.statusCode == 200 else { return nil }
-
-        guard let container = try? decodeItemsContainer(from: data),
-            let item = container.metadata?.first
-        else { return nil }
-
-        let durationMs = durationMilliseconds(from: item)
-        let offsetMs = item.viewOffset ?? 0
-        let positionSeconds = offsetMs / 1000.0
-        let percentage = durationMs > 0 ? offsetMs / durationMs : 0
-        let updatedAt = item.lastViewedAt.map { Date(timeIntervalSince1970: TimeInterval($0)) }
-        let isFinished = (item.viewCount ?? 0) > 0 && offsetMs <= 0
-
-        return (positionSeconds: positionSeconds, percentage: percentage, trackIndex: nil, updatedAt: updatedAt, isAbandoned: isFinished)
+        let tracks = (book.audioTracks ?? []).sorted { $0.startOffset < $1.startOffset }
+        let ids = tracks.isEmpty ? [book.id] : tracks.map(\.id)
+        var latest: (position: TimeInterval, date: Date)?
+        var allFinished = true
+        var duration = book.duration ?? 0
+        for (index, id) in ids.enumerated() {
+            let request = try buildRequest(path: "library/metadata/\(id)")
+            let (data, response) = try await performDataTask(for: request)
+            guard let http = response as? HTTPURLResponse, http.statusCode == 200,
+                let item = try decodeItemsContainer(from: data).metadata?.first
+            else { throw ProviderError.invalidResponse }
+            let offset = (item.viewOffset ?? 0) / 1000
+            let finished = (item.viewCount ?? 0) > 0 && offset <= 0
+            allFinished = allFinished && finished
+            if tracks.isEmpty { duration = durationMilliseconds(from: item) / 1000 }
+            let startOffset = tracks.isEmpty ? 0 : tracks[index].startOffset
+            let trackDuration = tracks.isEmpty ? duration : tracks[index].duration
+            let position = startOffset + (finished ? trackDuration : offset)
+            let date = item.lastViewedAt.map { Date(timeIntervalSince1970: TimeInterval($0)) }
+            if let date, date > (latest?.date ?? .distantPast) {
+                latest = (position, date)
+            } else if date == nil, offset > 0, latest == nil {
+                latest = (position, .distantPast)
+            }
+        }
+        let position = allFinished ? duration : (latest?.position ?? 0)
+        return (positionSeconds: position, percentage: duration > 0 ? position / duration : 0,
+                trackIndex: nil, updatedAt: latest?.date, isAbandoned: allFinished)
     }
 
     func updatePlaybackProgress(
@@ -1605,7 +1716,7 @@ class PlexProvider: IncrementalCatalogProvider, PlaybackSessionProvider, Audiobo
         }
     }
 
-    private func performDataTask(for request: URLRequest, retryCount: Int = 3) async throws -> (Data, URLResponse) {
+    func performDataTask(for request: URLRequest, retryCount: Int = 3) async throws -> (Data, URLResponse) {
         var currentRetry = 0
         while true {
             do {
@@ -1636,6 +1747,7 @@ class PlexProvider: IncrementalCatalogProvider, PlaybackSessionProvider, Audiobo
     private func mapPlexMetadataToBook(
         _ item: PlexMetadata,
         libraryId: String,
+        overrideID: String? = nil,
         overrideDuration: Double? = nil,
         partKey: String? = nil,
         audioTracks: [AudioTrack]? = nil,
@@ -1671,7 +1783,7 @@ class PlexProvider: IncrementalCatalogProvider, PlaybackSessionProvider, Audiobo
         AppLogger.network.debug("Mapping book: ID=\(item.ratingKey), Title=\"\(bookTitle)\", partKey=\(finalPartKey ?? "nil")")
 
         return Book(
-            id: item.ratingKey,
+            id: overrideID ?? item.ratingKey,
             title: bookTitle,
             author: author,
             narrator: narrator,
@@ -1957,6 +2069,7 @@ private final class PlexSectionsXMLParserDelegate: NSObject, XMLParserDelegate {
         let key: String
         let title: String
         let type: String
+        var paths: [String] = []
     }
 
     var sections: [SectionRecord] = []
@@ -1969,6 +2082,10 @@ private final class PlexSectionsXMLParserDelegate: NSObject, XMLParserDelegate {
         qualifiedName qName: String?,
         attributes attributeDict: [String: String] = [:]
     ) {
+        if elementName == "Location", let path = attributeDict["path"], !sections.isEmpty {
+            sections[sections.count - 1].paths.append(path)
+            return
+        }
         guard elementName == "Directory" else { return }
         guard let key = attributeDict["key"],
             let title = attributeDict["title"],

--- a/ios/enve/Networking/Providers/SiloProvider.swift
+++ b/ios/enve/Networking/Providers/SiloProvider.swift
@@ -506,9 +506,24 @@ final class SiloProvider: IncrementalCatalogProvider, PlaybackSessionProvider, A
     ) async throws {
         try await ensureAuthenticated()
         _ = try await ensureProfile()
+        if progress <= 0 {
+            let request = try makeRequest(path: "/watched/\(book.id)", method: "DELETE")
+            try await sendEmpty(request)
+            detailCache.removeValue(forKey: book.id)
+            return
+        }
         let detail = try await itemDetail(book.id)
-        guard let version = try await activeEbookVersion(for: detail) else { return }
+        guard let version = try await activeEbookVersion(for: detail) else {
+            throw ProviderError.invalidResponse
+        }
         let boundedProgress = min(max(progress, 0), 1)
+        // Silo latches completion until the watched state is explicitly cleared.
+        if boundedProgress < 0.99,
+            let previous = try await siloEbookProgress(for: book.id), (previous.progress ?? 0) >= 0.99
+        {
+            try await sendEmpty(makeRequest(path: "/watched/\(book.id)", method: "DELETE"))
+            detailCache.removeValue(forKey: book.id)
+        }
         let location = siloReaderLocation(
             from: epubLocator,
             progress: boundedProgress,
@@ -560,6 +575,7 @@ final class SiloProvider: IncrementalCatalogProvider, PlaybackSessionProvider, A
     func fetchAudiobookProgress(
         for book: Book
     ) async throws -> (positionSeconds: TimeInterval, percentage: Double, trackIndex: Int?, updatedAt: Date?, isAbandoned: Bool)? {
+        detailCache.removeValue(forKey: book.id)
         let detail = try await itemDetail(book.id)
         guard let userData = detail.userData,
             let position = userData.positionSeconds,

--- a/ios/enve/Persistence/BookStoreManager.swift
+++ b/ios/enve/Persistence/BookStoreManager.swift
@@ -62,11 +62,14 @@ final class BookStoreManager {
                 configurations: [config]
             )
         } catch {
-            AppLogger.general.error("BookStore: persistent store failed, resetting: \(error)")
+            AppLogger.general.error("BookStore: persistent store failed: \(error)")
 
-            backupLocation = StoreBackup.backup(storeURL: Self.storeURL, label: "BookStore")
-            Self.removeStoreFiles()
             do {
+                guard let backup = StoreBackup.backup(storeURL: Self.storeURL, label: "BookStore") else {
+                    throw error
+                }
+                backupLocation = backup
+                Self.removeStoreFiles()
                 resolvedContainer = try ModelContainer(
                     for: schema,
                     migrationPlan: BookStoreMigrationPlan.self,

--- a/ios/enve/Persistence/StoreBackup.swift
+++ b/ios/enve/Persistence/StoreBackup.swift
@@ -19,9 +19,7 @@ enum StoreBackup {
         let existing = companions.filter { fm.fileExists(atPath: $0.path) }
         guard !existing.isEmpty else { return nil }
 
-        pruneOldBackups(in: parent, label: label, keep: max(retainCount - 1, 0))
-
-        let backupDir = parent.appendingPathComponent("\(label).corrupt-\(timestampString())")
+        let backupDir = parent.appendingPathComponent("\(label).corrupt-\(timestampString())-\(UUID().uuidString)")
         do {
             try fm.createDirectory(at: backupDir, withIntermediateDirectories: true)
             for src in existing {
@@ -31,8 +29,10 @@ enum StoreBackup {
             AppLogger.general.warning(
                 "StoreBackup: copied \(existing.count) file(s) for \(label) to \(backupDir.lastPathComponent) before corruption reset"
             )
+            pruneOldBackups(in: parent, label: label, keep: max(retainCount, 1))
             return backupDir
         } catch {
+            try? fm.removeItem(at: backupDir)
             AppLogger.general.error("StoreBackup: failed to back up \(label): \(error)")
             return nil
         }

--- a/ios/enve/Plugins/ProviderSyncStrategy.swift
+++ b/ios/enve/Plugins/ProviderSyncStrategy.swift
@@ -4,6 +4,9 @@ struct ProviderSyncResult {
     let pulled: Int
     let pushed: Int
 
+    var failedBackends: [String] = []
+    var wasCancelled = false
+
     static let zero = ProviderSyncResult(pulled: 0, pushed: 0)
 }
 

--- a/ios/enve/Plugins/SyncSink.swift
+++ b/ios/enve/Plugins/SyncSink.swift
@@ -36,7 +36,7 @@ protocol SyncSink: AnyObject, Sendable {
 
     func isApplicable(to book: Book, domain: ProgressSyncDomain) -> Bool
 
-    func pull(book: Book, domain: ProgressSyncDomain) async -> SyncSnapshot?
+    func pull(book: Book, domain: ProgressSyncDomain) async throws -> SyncSnapshot?
 
     func push(_ update: ProgressUpdate) async throws
 }

--- a/ios/enve/Reader/Engine/ReaderProgressController.swift
+++ b/ios/enve/Reader/Engine/ReaderProgressController.swift
@@ -802,7 +802,11 @@ final class ReaderProgressController {
                 }
                 return
             }
-            let ebookForPush = libraryCache.bookInMemory(uniqueId: syncBook.uniqueId) ?? syncBook
+            var ebookForPush = libraryCache.bookInMemory(uniqueId: syncBook.uniqueId) ?? syncBook
+            ebookForPush.ebookProgress = progression
+            ebookForPush.epubLocator = locator
+            ebookForPush.isFinished = progression >= 0.99
+            ebookForPush.lastUpdate = capturedAt
             await SyncCoordinator.shared.pushProgress(
                 book: ebookForPush,
                 forceImmediate: true,

--- a/ios/enve/Screens/Hearth/HearthSeeAll.swift
+++ b/ios/enve/Screens/Hearth/HearthSeeAll.swift
@@ -39,7 +39,7 @@ struct HearthSeeAllScreen: View {
                                 GeometryReader { geo in
                                     ShelfCoverCell(book: book, width: geo.size.width, showsProgress: destination.kind != .fresh)
                                 }
-                                .aspectRatio(1 / 1.5, contentMode: .fit)
+                                .aspectRatio(1 / book.hearthCoverRatio, contentMode: .fit)
                             }
                             .buttonStyle(PressableStyle())
                         }

--- a/ios/enve/Screens/Library/LibraryBrowse.swift
+++ b/ios/enve/Screens/Library/LibraryBrowse.swift
@@ -480,7 +480,7 @@ struct LibraryAuthorRow: View {
     private var thumb: some View {
         if let cover {
             CoverTile(book: cover, width: 44, showsProgress: false, corner: 8)
-                .frame(width: 44, height: 66, alignment: .bottom)
+                .frame(width: 44, height: 44 * cover.hearthCoverRatio, alignment: .bottom)
         } else {
             RoundedRectangle(cornerRadius: 8, style: .continuous)
                 .fill(hearth.bgElevated)

--- a/ios/enve/Screens/Library/LibraryRows.swift
+++ b/ios/enve/Screens/Library/LibraryRows.swift
@@ -301,7 +301,7 @@ struct LibraryNarratorRow: View {
     private var thumb: some View {
         if let cover {
             CoverTile(book: cover, width: 44, showsProgress: false, corner: 8)
-                .frame(width: 44, height: 66, alignment: .bottom)
+                .frame(width: 44, height: 44 * cover.hearthCoverRatio, alignment: .bottom)
         } else {
             RoundedRectangle(cornerRadius: 8, style: .continuous)
                 .fill(hearth.bgElevated)

--- a/ios/enve/Screens/Player/PlayerPassageSheet.swift
+++ b/ios/enve/Screens/Player/PlayerPassageSheet.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+
+@available(iOS 26.0, *)
+struct PlayerPassageSheet: View {
+    let ebook: Book
+    let audiobook: Book
+    let position: TimeInterval
+
+    @Environment(EnveEngine.self) private var engine
+    @Environment(\.hearth) private var hearth
+    @Environment(\.dismiss) private var dismiss
+    @State private var match: LinkedBookSparseMatcher.Match?
+    @State private var failure: String?
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                HStack {
+                    Text("Find this passage")
+                        .font(.hearthDisplay(24, weight: .semibold))
+                    Spacer()
+                    Button("Close") { dismiss() }
+                }
+                Text("Apple on-device transcription · No audio is uploaded")
+                    .font(.hearthUI(13))
+                    .foregroundStyle(hearth.textSecondary)
+                if let match {
+                    Text(ebook.title).font(.hearthUI(16, weight: .semibold))
+                    Text(match.quote).font(.hearthDisplay(20))
+                        .textSelection(.enabled)
+                    Text("A matching passage near your paused position. Open it only if this looks right.")
+                        .font(.hearthUI(14))
+                        .foregroundStyle(hearth.textSecondary)
+                    Button("Open passage in ebook") {
+                        do {
+                            let target = try LinkedBookPassageService.bookForOpening(ebook, match: match)
+                            dismiss()
+                            engine.playback.presentReaderAfterDismissingPlayer(for: target)
+                        } catch {
+                            failure = error.localizedDescription
+                        }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(Hearth.accent)
+                    .disabled(engine.playback.currentBook?.stableId != audiobook.stableId)
+                } else if let failure {
+                    Text(failure).font(.hearthUI(16))
+                } else {
+                    ProgressView("Finding a matching passage…")
+                    Text("Reading a short audio sample using the same Apple speech system as Quick Sync.")
+                        .font(.hearthUI(14))
+                        .foregroundStyle(hearth.textSecondary)
+                }
+            }
+            .foregroundStyle(hearth.text)
+            .padding(24)
+        }
+        .task {
+            do {
+                let result = try await LinkedBookPassageService.find(ebook: ebook, audiobook: audiobook, at: position)
+                try Task.checkCancellation()
+                match = result
+            } catch is CancellationError {
+            } catch {
+                guard !Task.isCancelled else { return }
+                failure = error.localizedDescription
+            }
+        }
+    }
+}

--- a/ios/enve/Screens/Player/PlayerScreen.swift
+++ b/ios/enve/Screens/Player/PlayerScreen.swift
@@ -13,6 +13,7 @@ struct PlayerScreen: View {
     @State private var activeSheet: PlayerSheet?
     @State private var sleepChapterLabel: String?
     @State private var linkedEbook: Book?
+    @State private var showPassageUpdateRequired = false
     @AppStorage("player.showPercentRemaining") private var showPercentRemaining = false
     @AppStorage("player.scrubScope") private var scrubScopeRaw = PlayerScrubScope.book.rawValue
 
@@ -99,11 +100,24 @@ struct PlayerScreen: View {
                         LibrarianChatScreen(book: book)
                             .presentationDetents([.large])
                     }
+                case .passage:
+                    if #available(iOS 26.0, *), let ebook = linkedEbook, let audiobook = engine.playback.currentBook {
+                        PlayerPassageSheet(ebook: ebook, audiobook: audiobook, position: playerVM.progress)
+                            .presentationDetents([.medium, .large])
+                    } else {
+                        ContentUnavailableView("Link an ebook first", systemImage: "books.vertical", description: Text("Link this audiobook to its ebook from book details, then download both books to find matching passages on this device."))
+                            .presentationDetents([.medium])
+                    }
                 }
             }
             .hearthPresentationBackground()
             .presentationDragIndicator(.visible)
             .enveEnvironment()
+        }
+        .alert("Update Required", isPresented: $showPassageUpdateRequired) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("Finding passages in an ebook requires iOS 26.0 or newer.")
         }
         .alert("Two places in this book", isPresented: syncConflictPresented) {
             if let conflict = playerVM.playbackConflict {
@@ -164,8 +178,27 @@ struct PlayerScreen: View {
         HStack {
             GlyphButton(systemImage: "chevron.down", label: "Close player") { dismiss() }
             Spacer()
-            if linkedEbook != nil {
-                GlyphButton(systemImage: "book", label: "Switch to reading", action: switchToReading)
+            if engine.playback.currentBook?.mediaType == .audiobook {
+                Menu {
+                    if linkedEbook != nil {
+                        Button("Switch to reading", systemImage: "book", action: switchToReading)
+                    }
+                    if #available(iOS 26.0, *) {
+                        Button(playerVM.isPlaying ? "Pause to find this passage" : "Find this passage in ebook", systemImage: "text.magnifyingglass") {
+                            activeSheet = .passage
+                        }
+                        .disabled(playerVM.isPlaying)
+                    } else {
+                        Button("Find this passage in ebook", systemImage: "text.magnifyingglass") {
+                            showPassageUpdateRequired = true
+                        }
+                    }
+                } label: {
+                    Image(systemName: "book")
+                        .frame(width: 44, height: 44)
+                        .foregroundStyle(hearth.text)
+                }
+                .accessibilityLabel("Reading options")
             }
             queueButton
             PlayerAirPlayButton(tint: hearth.text, activeTint: ambient)
@@ -508,7 +541,7 @@ struct PlayerScreen: View {
 }
 
 private enum PlayerSheet: String, Identifiable {
-    case speed, sleep, chapters, bookmarks, audio, queue, ambient, librarian
+    case speed, sleep, chapters, bookmarks, audio, queue, ambient, librarian, passage
     var id: String { rawValue }
 }
 

--- a/ios/enve/Screens/Player/PlayerViewModel.swift
+++ b/ios/enve/Screens/Player/PlayerViewModel.swift
@@ -662,7 +662,7 @@ public class PlayerViewModel {
             locator: nil,
             title: title,
             note: note,
-            mediaType: book.mediaType,
+            mediaType: .audiobook,
             chapterTitle: chapter?.title
         )
         bookmarks = (bookmarks + [newBookmark]).sorted { $0.position < $1.position }
@@ -807,11 +807,11 @@ public class PlayerViewModel {
     }
 
     func seekToBookmark(_ bookmark: Bookmark) {
-        if bookmark.mediaType == .ebook {
-            NotificationCenter.default.post(name: NSNotification.Name("SeekToEbookBookmark"), object: bookmark)
-        } else {
-            seek(to: bookmark.position)
+        if let position = PlayerBookmarkNavigation.audioSeekPosition(for: bookmark, playbackBook: activeBook) {
+            seek(to: position)
+            return
         }
+        NotificationCenter.default.post(name: NSNotification.Name("SeekToEbookBookmark"), object: bookmark)
     }
 
     func setSleepTimerToEndOfChapter(fadeOut: Bool = true) {

--- a/ios/enve/Screens/Sources/AddSourceScreen.swift
+++ b/ios/enve/Screens/Sources/AddSourceScreen.swift
@@ -6,6 +6,7 @@ struct AddSourceScreen: View {
     @Environment(\.dismiss) private var dismiss
 
     @State private var selected: AddSourceProvider?
+    @State private var didAddSource = false
 
     var body: some View {
         GeometryReader { geo in
@@ -55,10 +56,14 @@ struct AddSourceScreen: View {
         }
         .background(HearthBackground())
         .toolbar(.hidden, for: .navigationBar)
-        .sheet(item: $selected) { provider in
+        .sheet(item: $selected, onDismiss: {
+            guard didAddSource else { return }
+            didAddSource = false
+            dismiss()
+        }) { provider in
             AddSourceRouter(provider: provider) {
+                didAddSource = true
                 selected = nil
-                dismiss()
             }
             .enveEnvironment()
         }

--- a/ios/enve/Screens/Sources/SourcesProviderFormScreen.swift
+++ b/ios/enve/Screens/Sources/SourcesProviderFormScreen.swift
@@ -548,8 +548,10 @@ struct SourcesProviderFormScreen: View {
             return presetURL
         }
         var trimmed = serverURL.trimmingCharacters(in: .whitespacesAndNewlines)
-        while trimmed.hasSuffix("/") {
-            trimmed = String(trimmed.dropLast())
+        if capability.providerType != .opds {
+            while trimmed.hasSuffix("/") {
+                trimmed = String(trimmed.dropLast())
+            }
         }
         guard !trimmed.isEmpty else { return trimmed }
         return urlScheme.rawValue + trimmed

--- a/ios/enve/Screens/Sources/SourcesQuickConnectScreen.swift
+++ b/ios/enve/Screens/Sources/SourcesQuickConnectScreen.swift
@@ -10,6 +10,7 @@ struct SourcesQuickConnectScreen: View {
     @State private var statusMessage: String?
     @State private var errorMessage: String?
     @State private var detected: DetectedServer?
+    @State private var didAddSource = false
     @State private var showingManual = false
     @State private var probeTask: Task<Void, Never>?
 
@@ -75,7 +76,11 @@ struct SourcesQuickConnectScreen: View {
         .background(HearthBackground())
         .toolbar(.hidden, for: .navigationBar)
         .onDisappear { probeTask?.cancel() }
-        .sheet(item: $detected) { server in
+        .sheet(item: $detected, onDismiss: {
+            guard didAddSource else { return }
+            didAddSource = false
+            dismiss()
+        }) { server in
             detectedLogin(for: server).enveEnvironment()
         }
         .sheet(isPresented: $showingManual) {
@@ -146,7 +151,7 @@ struct SourcesQuickConnectScreen: View {
     }
 
     private func finish() {
+        didAddSource = true
         detected = nil
-        dismiss()
     }
 }

--- a/ios/enve/Services/Audio/PlaybackManager.swift
+++ b/ios/enve/Services/Audio/PlaybackManager.swift
@@ -2052,6 +2052,7 @@ final class PlaybackManager {
 
         setupAudioSession()
         announcePlaybackOwnership()
+        activateNowPlayingSession(for: player)
         AppLogger.player.info("Setting player rate to \(playbackSpeed)x")
         player.rate = playbackSpeed
         isPlaying = true
@@ -2168,10 +2169,10 @@ final class PlaybackManager {
             timeObserver = nil
         }
 
-        player = nil
         clearPlaybackItemObservers()
         resetPlaybackRecovery()
         clearNowPlayingSession()
+        player = nil
 
         stopSyncTimer()
         lastStatsTickAt = .distantPast
@@ -2223,9 +2224,11 @@ final class PlaybackManager {
                 let session = MPNowPlayingSession(players: [player])
                 session.automaticallyPublishesNowPlayingInfo = false
                 nowPlayingSession = session
-                NowPlayingCoordinator.shared.setNowPlayingSession(session, for: self)
             }
-            nowPlayingSession?.becomeActiveIfPossible { _ in }
+            if let session = nowPlayingSession {
+                NowPlayingCoordinator.shared.setNowPlayingSession(session, for: self)
+                session.becomeActiveIfPossible { _ in }
+            }
         }
         #endif
     }
@@ -2233,11 +2236,8 @@ final class PlaybackManager {
     private func clearNowPlayingSession() {
         #if os(iOS)
         if #available(iOS 16.0, *) {
-            if let session = nowPlayingSession {
-                session.players.forEach { session.removePlayer($0) }
-            }
-            nowPlayingSession = nil
             NowPlayingCoordinator.shared.clearNowPlayingSession(if: self)
+            nowPlayingSession = nil
         }
         #endif
     }

--- a/ios/enve/Services/Audiobookshelf/AudiobookshelfService.swift
+++ b/ios/enve/Services/Audiobookshelf/AudiobookshelfService.swift
@@ -1213,7 +1213,7 @@ public final class AudiobookshelfService: @unchecked Sendable {
             currentTime: currentTime,
             duration: duration,
             progress: progress,
-            isFinished: isFinished
+            isFinished: isFinished || currentTime <= 0 ? isFinished : nil
         )
         request.httpBody = try encoder.encode(progressRequest)
 
@@ -1226,10 +1226,7 @@ public final class AudiobookshelfService: @unchecked Sendable {
         var request = createRequest(url: url, method: "PATCH", backend: backend)
 
         let body: [String: Any] = [
-            "progress": ebookProgress,
             "ebookProgress": ebookProgress,
-            "currentTime": 0,
-            "duration": 0,
             "isFinished": isFinished,
         ]
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
@@ -1908,7 +1905,7 @@ public final class AudiobookshelfService: @unchecked Sendable {
             currentTime: currentTime,
             duration: duration,
             progress: progress,
-            isFinished: isFinished
+            isFinished: isFinished || currentTime <= 0 ? isFinished : nil
         )
         request.httpBody = try encoder.encode(progressRequest)
 

--- a/ios/enve/Services/BookBridge/BookBridgeMappingImporter.swift
+++ b/ios/enve/Services/BookBridge/BookBridgeMappingImporter.swift
@@ -20,18 +20,16 @@ final class BookBridgeMappingImporter {
     func runImport(baseURL: URL) async throws -> Result {
         let mappings = try await client.fetchMappings(baseURL: baseURL)
 
-        let audiobooksByABSId = Dictionary(
-            uniqueKeysWithValues: AppState.shared.allBooks
-                .filter { $0.mediaType == .audiobook && $0.source == .audiobookshelf }
-                .map { ($0.id, $0) }
+        let audiobooksByABSId = Self.booksIndexedByUniqueKey(
+            AppState.shared.allBooks.filter { $0.mediaType == .audiobook && $0.source == .audiobookshelf },
+            key: { $0.id }
         )
 
         let ebooksByDocHash: [String: Book] = {
             let links = KOReaderSyncService.shared.links
-            let booksByStableId = Dictionary(
-                uniqueKeysWithValues: AppState.shared.allBooks
-                    .filter { $0.mediaType == .ebook }
-                    .map { ($0.stableId, $0) }
+            let booksByStableId = Self.booksIndexedByUniqueKey(
+                AppState.shared.allBooks.filter { $0.mediaType == .ebook },
+                key: { $0.stableId }
             )
             var map: [String: Book] = [:]
             for (stableId, link) in links {
@@ -83,5 +81,24 @@ final class BookBridgeMappingImporter {
 
         EbookLinkStore.shared.saveLinks()
         return result
+    }
+
+    static func booksIndexedByUniqueKey<Key: Hashable>(
+        _ books: [Book],
+        key: (Book) -> Key
+    ) -> [Key: Book] {
+        var indexed: [Key: Book] = [:]
+        var duplicateKeys = Set<Key>()
+
+        for book in books {
+            let bookKey = key(book)
+            guard !duplicateKeys.contains(bookKey) else { continue }
+            if indexed.updateValue(book, forKey: bookKey) != nil {
+                indexed.removeValue(forKey: bookKey)
+                duplicateKeys.insert(bookKey)
+            }
+        }
+
+        return indexed
     }
 }

--- a/ios/enve/Services/Engine/SyncEngine.swift
+++ b/ios/enve/Services/Engine/SyncEngine.swift
@@ -90,6 +90,8 @@ final class SyncEngine {
             return BookSyncStatusUpdate(phase: .syncing, message: "Checking the server...")
         case .pullCompleted(_, let applied):
             return BookSyncStatusUpdate(phase: .idle, message: applied ? "Brought back newer progress" : "Up to date")
+        case .pullFailed(_, let error):
+            return BookSyncStatusUpdate(phase: .error(error), message: "Couldn't check the server")
         case .pushStarted:
             return BookSyncStatusUpdate(phase: .syncing, message: "Sending your progress...")
         case .pushCompleted:

--- a/ios/enve/Services/Hardcover/HardcoverService.swift
+++ b/ios/enve/Services/Hardcover/HardcoverService.swift
@@ -390,9 +390,7 @@ public final class HardcoverService: Sendable {
             }
             """
         let response: GenericUpdateResponse = try await performQuery(mutation)
-        if let error = response.updateUserBook?.error {
-            throw HardcoverError.graphQLError(message: error)
-        }
+        try response.validate()
     }
 
     public func markBookAsStarted(userBookId: Int) async throws {
@@ -455,7 +453,8 @@ public final class HardcoverService: Sendable {
                     }
                 }
                 """
-            let _: UpdateReadProgressResponse = try await performQuery(mutation)
+            let response: UpdateReadProgressResponse = try await performQuery(mutation)
+            try response.validate()
             return readId
         } else {
             return try await insertReadRecord(
@@ -519,10 +518,9 @@ public final class HardcoverService: Sendable {
 
             do {
                 let response: InsertReadSessionResponse = try await performQuery(mutation, suppressGraphQLErrorLogging: true)
+                let createdReadId = try response.createdReadId()
                 await insertReadModeStore.set(mode)
-
-                let createdReadId = response.insertUserBookRead?.userBookRead?.id ?? 0
-                if isFinished, mode == .progressPages, createdReadId > 0 {
+                if isFinished, mode == .progressPages {
                     try? await markReadSessionFinished(readId: createdReadId)
                 }
                 return createdReadId
@@ -556,7 +554,8 @@ public final class HardcoverService: Sendable {
                 }
             }
             """
-        let _: UpdateReadProgressResponse = try await performQuery(mutation)
+        let response: UpdateReadProgressResponse = try await performQuery(mutation)
+        try response.validate()
     }
 
     public func rateBook(userBookId: Int, rating: Double) async throws {
@@ -571,7 +570,8 @@ public final class HardcoverService: Sendable {
                 }
             }
             """
-        let _: GenericUpdateResponse = try await performQuery(mutation)
+        let response: GenericUpdateResponse = try await performQuery(mutation)
+        try response.validate()
     }
 
     public func reviewBook(userBookId: Int, reviewText: String) async throws {
@@ -584,7 +584,8 @@ public final class HardcoverService: Sendable {
                 }
             }
             """
-        let _: GenericUpdateResponse = try await performQuery(mutation)
+        let response: GenericUpdateResponse = try await performQuery(mutation)
+        try response.validate()
     }
 
     public func getBookReviews(bookId: Int, limit: Int = 20) async throws -> [HardcoverReview] {
@@ -1004,7 +1005,8 @@ public final class HardcoverService: Sendable {
                 }
             }
             """
-        let _: UpdateReadProgressResponse = try await performQuery(mutation)
+        let response: UpdateReadProgressResponse = try await performQuery(mutation)
+        try response.validate()
     }
 
     public func markMatchedBookAsFinished(localBookId: String) async throws {
@@ -1117,7 +1119,8 @@ public final class HardcoverService: Sendable {
                 }
             }
             """
-        let _: UpdateReadProgressResponse = try await performQuery(mutation)
+        let response: UpdateReadProgressResponse = try await performQuery(mutation)
+        try response.validate()
     }
 
     private func mapToLegacyUserBook(_ data: UserBookFullData) -> HardcoverUserBookLegacy {
@@ -1418,11 +1421,6 @@ private struct TypesenseDoc: Decodable {
     let image: HardcoverImage?
     let slug: String?
 
-    enum CodingKeys: String, CodingKey {
-        case id, title, description, image, slug
-        case releaseYear = "release_year"
-        case authorNames = "author_names"
-    }
 }
 
 private struct UserSearchResponse: Decodable {
@@ -1440,82 +1438,64 @@ private struct InsertUserBookMutResponse: Decodable {
     struct InsertData: Decodable {
         let error: String?
         let userBook: UBData?
-        enum CodingKeys: String, CodingKey {
-            case error
-            case userBook = "user_book"
-        }
     }
     struct UBData: Decodable { let id: Int }
-    enum CodingKeys: String, CodingKey {
-        case insertUserBook = "insert_user_book"
-    }
 }
 
-private struct GenericUpdateResponse: Decodable {
+struct GenericUpdateResponse: Decodable {
+    func validate() throws {
+        guard let result = updateUserBook else { throw HardcoverError.invalidResponse }
+        if let error = result.error, !error.isEmpty { throw HardcoverError.graphQLError(message: error) }
+    }
+
     let updateUserBook: UpdateData?
     struct UpdateData: Decodable {
         let error: String?
-    }
-    enum CodingKeys: String, CodingKey {
-        case updateUserBook = "update_user_book"
     }
 }
 
 private struct GenericDeleteResponse: Decodable {
     let deleteUserBook: DeleteData?
     struct DeleteData: Decodable { let id: Int? }
-    enum CodingKeys: String, CodingKey {
-        case deleteUserBook = "delete_user_book"
-    }
 }
 
 private struct GenericMutResponse: Decodable {}
 
-private struct InsertReadSessionResponse: Decodable {
+struct InsertReadSessionResponse: Decodable {
+    func createdReadId() throws -> Int {
+        guard let result = insertUserBookRead else { throw HardcoverError.invalidResponse }
+        if let error = result.error, !error.isEmpty { throw HardcoverError.graphQLError(message: error) }
+        guard let id = result.userBookRead?.id, id > 0 else { throw HardcoverError.invalidResponse }
+        return id
+    }
+
     let insertUserBookRead: InsertData?
     struct InsertData: Decodable {
         let error: String?
         let userBookRead: ReadData?
-        enum CodingKeys: String, CodingKey {
-            case error
-            case userBookRead = "user_book_read"
-        }
     }
     struct ReadData: Decodable {
         let id: Int
         let startedAt: String?
         let progressPages: Int?
-        enum CodingKeys: String, CodingKey {
-            case id
-            case startedAt = "started_at"
-            case progressPages = "progress_pages"
-        }
-    }
-    enum CodingKeys: String, CodingKey {
-        case insertUserBookRead = "insert_user_book_read"
     }
 }
 
-private struct UpdateReadProgressResponse: Decodable {
+struct UpdateReadProgressResponse: Decodable {
+    func validate() throws {
+        guard let result = updateUserBookRead else { throw HardcoverError.invalidResponse }
+        if let error = result.error, !error.isEmpty { throw HardcoverError.graphQLError(message: error) }
+        guard result.userBookRead != nil else { throw HardcoverError.invalidResponse }
+    }
+
     let updateUserBookRead: UpdateData?
     struct UpdateData: Decodable {
         let error: String?
         let userBookRead: ReadData?
-        enum CodingKeys: String, CodingKey {
-            case error
-            case userBookRead = "user_book_read"
-        }
     }
     struct ReadData: Decodable {
         let id: Int
         let progressPages: Int?
-        enum CodingKeys: String, CodingKey {
-            case id
-            case progressPages = "progress_pages"
-        }
-    }
-    enum CodingKeys: String, CodingKey {
-        case updateUserBookRead = "update_user_book_read"
     }
 }
 

--- a/ios/enve/Services/Intelligence/AudiobookTranscriptionService.swift
+++ b/ios/enve/Services/Intelligence/AudiobookTranscriptionService.swift
@@ -74,7 +74,8 @@ final class AudiobookTranscriptionService {
         guard activeBookStableId == nil else {
             throw AudiobookTranscriptionError.transcriptionBusy
         }
-
+        activeBookStableId = book.stableId
+        defer { activeBookStableId = nil }
         let locale = try await supportedLocale(for: book)
         let tracks = try await resolver.localTracks(for: book)
         let start = min(max(startTime, 0), tracks.totalDuration)

--- a/ios/enve/Services/KOReader/KOReaderSyncService.swift
+++ b/ios/enve/Services/KOReader/KOReaderSyncService.swift
@@ -46,7 +46,7 @@ final class KOReaderSyncService {
         if let data = userDefaults.data(forKey: linksKey),
             let decoded = try? JSONDecoder().decode([KOReaderBookLink].self, from: data)
         {
-            self.links = Dictionary(uniqueKeysWithValues: decoded.map { ($0.bookStableId, $0) })
+            self.links = Self.restoredLinks(decoded)
         }
 
         self.lastSyncDate = userDefaults.object(forKey: lastSyncKey) as? Date
@@ -261,6 +261,10 @@ final class KOReaderSyncService {
     }
 
     func link(for bookStableId: String) -> KOReaderBookLink? { links[bookStableId] }
+
+    static func restoredLinks(_ decoded: [KOReaderBookLink]) -> [String: KOReaderBookLink] {
+        Dictionary(decoded.map { ($0.bookStableId, $0) }, uniquingKeysWith: { _, latest in latest })
+    }
 
     func ensureDocumentHash(for book: Book) async -> String? {
         if let existing = links[book.stableId] { return existing.documentHash }

--- a/ios/enve/Services/ListeningStats/AudiobookshelfProgressSync.swift
+++ b/ios/enve/Services/ListeningStats/AudiobookshelfProgressSync.swift
@@ -45,7 +45,7 @@ final class AudiobookshelfProgressSync: ProgressSyncProtocol, @unchecked Sendabl
                 currentTime: progress.currentTime ?? 0,
                 duration: progress.duration ?? 0,
                 progress: progress.progress ?? 0,
-                isFinished: progress.isFinished ?? false,
+                isFinished: progress.resolvedIsFinished,
                 lastUpdate: progress.lastUpdate,
                 backendId: backend.id
             )
@@ -66,7 +66,7 @@ final class AudiobookshelfProgressSync: ProgressSyncProtocol, @unchecked Sendabl
             currentTime: progress.currentTime ?? 0,
             duration: progress.duration ?? 0,
             progress: progress.progress ?? 0,
-            isFinished: progress.isFinished ?? false,
+            isFinished: progress.resolvedIsFinished,
             lastUpdate: progress.lastUpdate,
             backendId: backend.id
         )

--- a/ios/enve/Services/Network/OAuthManager.swift
+++ b/ios/enve/Services/Network/OAuthManager.swift
@@ -101,6 +101,7 @@ struct OAuthToken: Codable, Sendable {
         case expiresIn = "expires_in"
         case tokenType = "token_type"
         case scope
+        case issuedAt = "issued_at"
     }
 
     init(accessToken: String, refreshToken: String?, expiresIn: Int?, tokenType: String, scope: String?, issuedAt: Date) {
@@ -119,7 +120,7 @@ struct OAuthToken: Codable, Sendable {
         expiresIn = try container.decodeIfPresent(Int.self, forKey: .expiresIn)
         tokenType = try container.decode(String.self, forKey: .tokenType)
         scope = try container.decodeIfPresent(String.self, forKey: .scope)
-        issuedAt = Date()
+        issuedAt = try container.decodeIfPresent(Date.self, forKey: .issuedAt) ?? Date()
     }
 
     func encode(to encoder: Encoder) throws {
@@ -129,6 +130,7 @@ struct OAuthToken: Codable, Sendable {
         try container.encodeIfPresent(expiresIn, forKey: .expiresIn)
         try container.encode(tokenType, forKey: .tokenType)
         try container.encodeIfPresent(scope, forKey: .scope)
+        try container.encode(issuedAt, forKey: .issuedAt)
     }
 
     var isExpired: Bool {
@@ -158,7 +160,7 @@ enum OAuthError: LocalizedError {
         case .userCancelled:
             return "Authentication cancelled by user"
         case .invalidConfiguration:
-            return "OAuth credentials not configured. Please set up your client ID and secret in OAuthManager.swift"
+            return "OAuth is not configured for this service."
         case .invalidResponse:
             return "Invalid response from authorization server"
         case .networkError(let error):
@@ -304,11 +306,7 @@ final class OAuthManager: NSObject, ObservableObject {
             parameters["client_secret"] = clientSecret
         }
 
-        request.httpBody =
-            parameters
-            .map { "\($0.key)=\($0.value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? $0.value)" }
-            .joined(separator: "&")
-            .data(using: .utf8)
+        request.httpBody = Self.formEncodedBody(parameters)
 
         let (data, response) = try await session.data(for: request)
 
@@ -352,11 +350,7 @@ final class OAuthManager: NSObject, ObservableObject {
             parameters["client_secret"] = clientSecret
         }
 
-        request.httpBody =
-            parameters
-            .map { "\($0.key)=\($0.value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? $0.value)" }
-            .joined(separator: "&")
-            .data(using: .utf8)
+        request.httpBody = Self.formEncodedBody(parameters)
 
         let (data, response) = try await session.data(for: request)
 
@@ -391,6 +385,14 @@ final class OAuthManager: NSObject, ObservableObject {
         }
 
         return token
+    }
+
+    static func formEncodedBody(_ parameters: [String: String]) -> Data {
+        let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~")
+        let body = parameters.sorted { $0.key < $1.key }.map { key, value in
+            "\(key.addingPercentEncoding(withAllowedCharacters: allowed)!)=\(value.addingPercentEncoding(withAllowedCharacters: allowed)!)"
+        }.joined(separator: "&")
+        return Data(body.utf8)
     }
 
     private struct PKCEPair {

--- a/ios/enve/Services/Player/AudiobookPlaybackCoordinator.swift
+++ b/ios/enve/Services/Player/AudiobookPlaybackCoordinator.swift
@@ -186,8 +186,9 @@ final class AudiobookPlaybackCoordinator: BookPlaybackStarting {
             appState.currentBook = bookToPlay
             _ = appState.libraryCache.replaceExisting(bookToPlay)
 
-            if !(bookToPlay.chapters?.isEmpty ?? true) {
+            if let chapters = bookToPlay.chapters, !chapters.isEmpty {
                 await appState.bookStore.upsertBooks([bookToPlay])
+                ActivePlayback.composition.bookMetadataUpdater.updateChapters(chapters, for: bookToPlay)
             }
             playback.playBook(bookToPlay, provider: playbackProvider)
         }

--- a/ios/enve/Services/Player/AutoSleepService.swift
+++ b/ios/enve/Services/Player/AutoSleepService.swift
@@ -13,7 +13,7 @@ enum AutoSleepPolicy {
     }
 
     nonisolated static func currentWindowStart(now: Date, startMinutes: Int, calendar: Calendar) -> Date {
-        let todayStart = calendar.startOfDay(for: now).addingTimeInterval(TimeInterval(startMinutes * 60))
+        let todayStart = calendar.date(bySettingHour: startMinutes / 60, minute: startMinutes % 60, second: 0, of: now)!
         if now >= todayStart { return todayStart }
         return calendar.date(byAdding: .day, value: -1, to: todayStart) ?? todayStart
     }

--- a/ios/enve/Services/Player/NowPlayingCoordinator.swift
+++ b/ios/enve/Services/Player/NowPlayingCoordinator.swift
@@ -9,7 +9,7 @@ import UIKit
 @MainActor
 final class NowPlayingCoordinator {
     static let shared = NowPlayingCoordinator()
-    private init() {}
+    init() {}
 
     private weak var activeTarget: (any RemoteCommandTarget)?
     #if os(iOS)
@@ -40,9 +40,7 @@ final class NowPlayingCoordinator {
 
     #if os(iOS)
     func setNowPlayingSession(_ session: MPNowPlayingSession, for target: any RemoteCommandTarget) {
-        if let current = nowPlayingSession, current !== session {
-            current.players.forEach { current.removePlayer($0) }
-        }
+        // Retire sessions intact; explicit removePlayer calls trigger an iOS 27 KVO exception.
         nowPlayingSession = session
         nowPlayingSessionOwner = target
         if activeTarget != nil {
@@ -52,9 +50,6 @@ final class NowPlayingCoordinator {
 
     func clearNowPlayingSession(if target: any RemoteCommandTarget) {
         guard nowPlayingSessionOwner === target else { return }
-        if let current = nowPlayingSession {
-            current.players.forEach { current.removePlayer($0) }
-        }
         nowPlayingSession = nil
         nowPlayingSessionOwner = nil
         if activeTarget != nil {

--- a/ios/enve/Services/Player/PlaybackQueueCoordinator.swift
+++ b/ios/enve/Services/Player/PlaybackQueueCoordinator.swift
@@ -246,6 +246,7 @@ final class PlaybackQueueCoordinator {
             {
                 playable = stored
             }
+            guard !Task.isCancelled, self.startRequestID == requestID else { return }
             if resetIfFinished, PlaybackQueuePolicy.isFinished(playable) {
                 self.progressStore.resetToBeginning(for: playable)
                 let observedAt = Date()

--- a/ios/enve/Services/Player/PlayerBookmarkService.swift
+++ b/ios/enve/Services/Player/PlayerBookmarkService.swift
@@ -1,5 +1,20 @@
 import Foundation
 
+enum PlayerBookmarkNavigation {
+    static func audioSeekPosition(for bookmark: Bookmark, playbackBook: Book?) -> TimeInterval? {
+        if bookmark.mediaType == .audiobook {
+            return bookmark.position
+        }
+        guard playbackBook?.hasEPUB3MediaOverlay == true,
+            bookmark.locator == nil,
+            !bookmark.isRemotePlaceholder
+        else {
+            return nil
+        }
+        return bookmark.position
+    }
+}
+
 public class PlayerBookmarkService {
     private let storageService: StorageService
 

--- a/ios/enve/Services/Reader/MediaOverlayPlaybackService.swift
+++ b/ios/enve/Services/Reader/MediaOverlayPlaybackService.swift
@@ -60,9 +60,7 @@ final class MediaOverlayPlaybackService {
     }
 
     func prepareAudioTracks(for book: Book) async throws -> OverlayAudioResult {
-        guard let fileURL = resolveEbookFile(for: book) else {
-            throw OverlayPlaybackError.noEbookFile
-        }
+        let fileURL = try await resolveEbookFile(for: book)
         return try await prepareAudioTracks(for: book, fileURL: fileURL)
     }
 
@@ -572,8 +570,11 @@ final class MediaOverlayPlaybackService {
         }
     }
 
-    private func resolveEbookFile(for book: Book) -> URL? {
-        LocalEbookImporter.shared.resolveEbookForOverlay(book: book)
+    private func resolveEbookFile(for book: Book) async throws -> URL {
+        if let existing = LocalEbookImporter.shared.resolveEbookForOverlay(book: book) {
+            return existing
+        }
+        return try await UnifiedDownloadService.shared.prepareReaderAsset(for: book)
     }
 
     private func loadIndexedAudioTracks(for book: Book, epubFileURL: URL) -> OverlayAudioResult? {

--- a/ios/enve/Services/Reader/MediaOverlayPlayer.swift
+++ b/ios/enve/Services/Reader/MediaOverlayPlayer.swift
@@ -354,9 +354,11 @@ final class MediaOverlayPlayer: NSObject, ObservableObject {
                 let session = MPNowPlayingSession(players: [player])
                 session.automaticallyPublishesNowPlayingInfo = false
                 nowPlayingSession = session
-                NowPlayingCoordinator.shared.setNowPlayingSession(session, for: self)
             }
-            nowPlayingSession?.becomeActiveIfPossible { _ in }
+            if let session = nowPlayingSession {
+                NowPlayingCoordinator.shared.setNowPlayingSession(session, for: self)
+                session.becomeActiveIfPossible { _ in }
+            }
         }
         #endif
     }
@@ -369,11 +371,8 @@ final class MediaOverlayPlayer: NSObject, ObservableObject {
     private func clearNowPlayingSession() {
         #if os(iOS)
         if #available(iOS 16.0, *) {
-            if let session = nowPlayingSession {
-                session.players.forEach { session.removePlayer($0) }
-            }
-            nowPlayingSession = nil
             NowPlayingCoordinator.shared.clearNowPlayingSession(if: self)
+            nowPlayingSession = nil
         }
         #endif
     }

--- a/ios/enve/Services/Sync/BookOrbitSyncStrategy.swift
+++ b/ios/enve/Services/Sync/BookOrbitSyncStrategy.swift
@@ -34,6 +34,7 @@ final class BookOrbitSyncStrategy: ProviderSyncStrategy {
         guard !connections.isEmpty else { return .zero }
 
         var pulled = 0
+        var failedBackends: [String] = []
         var pushed = 0
 
         for connection in connections {
@@ -107,9 +108,11 @@ final class BookOrbitSyncStrategy: ProviderSyncStrategy {
                     pulled += result.pulled
                     pushed += result.pushed
                 }
-            } catch is CancellationError {
-                return ProviderSyncResult(pulled: pulled, pushed: pushed)
             } catch {
+                if error is CancellationError || (error as? URLError)?.code == .cancelled {
+                    return ProviderSyncResult(pulled: pulled, pushed: pushed, failedBackends: failedBackends, wasCancelled: true)
+                }
+                if !failedBackends.contains(connection.name) { failedBackends.append(connection.name) }
                 AppLogger.sync.error("[BookOrbit] activity sync failed: \(error.localizedDescription)")
             }
         }
@@ -117,7 +120,7 @@ final class BookOrbitSyncStrategy: ProviderSyncStrategy {
         if pulled > 0 {
             NotificationCenter.default.post(name: .continueListeningNeedsRefresh, object: nil)
         }
-        return ProviderSyncResult(pulled: pulled, pushed: pushed)
+        return ProviderSyncResult(pulled: pulled, pushed: pushed, failedBackends: failedBackends)
     }
 
     private func pullLegacyContinueSnapshot(

--- a/ios/enve/Services/Sync/BookloreAudiobookSyncStrategy.swift
+++ b/ios/enve/Services/Sync/BookloreAudiobookSyncStrategy.swift
@@ -72,6 +72,7 @@ final class BookloreAudiobookSyncStrategy: ProviderSyncStrategy {
         guard !providerBookById.isEmpty else { return .zero }
 
         var pullCount = 0
+        var failedBackends: [String] = []
         var pushCount = 0
         var didMutateContinueListeningState = false
 
@@ -87,7 +88,11 @@ final class BookloreAudiobookSyncStrategy: ProviderSyncStrategy {
             }
 
             let selectedBooks: [Book]
-            if totalEligible <= 500 {
+            if force {
+                selectedBooks = await books.books(
+                    source: Book.BookSource.booklore.rawValue, providerId: providerId, mediaType: "audiobook"
+                )
+            } else if totalEligible <= 500 {
 
                 selectedBooks = idMap.values
                     .sorted { lhs, rhs in
@@ -102,6 +107,10 @@ final class BookloreAudiobookSyncStrategy: ProviderSyncStrategy {
                 do {
                     recentBooks = try await provider.fetchRecentBooks(limit: recentFetchLimit)
                 } catch {
+                    if error is CancellationError || (error as? URLError)?.code == .cancelled {
+                        return ProviderSyncResult(pulled: pullCount, pushed: pushCount, failedBackends: failedBackends, wasCancelled: true)
+                    }
+                    if !failedBackends.contains(provider.connection.name) { failedBackends.append(provider.connection.name) }
                     AppLogger.sync.error(
                         "Failed to fetch Booklore recent audiobooks for provider \(providerId): \(error.localizedDescription)"
                     )
@@ -142,9 +151,9 @@ final class BookloreAudiobookSyncStrategy: ProviderSyncStrategy {
                 let diagnosticID = DiagnosticLogSanitizer.identifier(for: book.stableId)
                 if Task.isCancelled {
                     AppLogger.sync.debug("Booklore audiobook sync cancelled bookDiagnosticID=\(diagnosticID)")
-                    return ProviderSyncResult(pulled: pullCount, pushed: pushCount)
+                    return ProviderSyncResult(pulled: pullCount, pushed: pushCount, failedBackends: failedBackends, wasCancelled: true)
                 }
-                guard book.stableId != currentlyPlaying else { continue }
+                guard book.stableId != currentlyPlaying, PendingSyncQueueStore.shared.entries[book.stableId] == nil else { continue }
 
                 do {
                     let local = BookProgressStore.shared.loadProgress(for: book)
@@ -290,6 +299,10 @@ final class BookloreAudiobookSyncStrategy: ProviderSyncStrategy {
                         }
                     }
                 } catch {
+                    if error is CancellationError || (error as? URLError)?.code == .cancelled {
+                        return ProviderSyncResult(pulled: pullCount, pushed: pushCount, failedBackends: failedBackends, wasCancelled: true)
+                    }
+                    if !failedBackends.contains(provider.connection.name) { failedBackends.append(provider.connection.name) }
                     AppLogger.sync.error(
                         "Failed to sync Booklore audiobook bookDiagnosticID=\(diagnosticID): \(error.localizedDescription)"
                     )
@@ -303,6 +316,6 @@ final class BookloreAudiobookSyncStrategy: ProviderSyncStrategy {
                 NotificationCenter.default.post(name: .continueListeningNeedsRefresh, object: nil)
             }
         }
-        return ProviderSyncResult(pulled: pullCount, pushed: pushCount)
+        return ProviderSyncResult(pulled: pullCount, pushed: pushCount, failedBackends: failedBackends)
     }
 }

--- a/ios/enve/Services/Sync/BookloreEbookSyncStrategy.swift
+++ b/ios/enve/Services/Sync/BookloreEbookSyncStrategy.swift
@@ -101,6 +101,7 @@ final class BookloreEbookSyncStrategy: ProviderSyncStrategy {
         }
 
         var pullCount = 0
+        var failedBackends: [String] = []
         var pushCount = 0
         var updatedInMemoryBooks: [Book] = []
 
@@ -140,9 +141,22 @@ final class BookloreEbookSyncStrategy: ProviderSyncStrategy {
                     }
                 }
             } catch {
+                if error is CancellationError || (error as? URLError)?.code == .cancelled {
+                    return ProviderSyncResult(pulled: pullCount, pushed: pushCount, failedBackends: failedBackends, wasCancelled: true)
+                }
+                if !failedBackends.contains(provider.connection.name) { failedBackends.append(provider.connection.name) }
                 AppLogger.sync.error(
                     "Failed to fetch Booklore recent books providerDiagnosticID=\(DiagnosticLogSanitizer.identifier(for: providerId.uuidString)): \(error.localizedDescription)"
                 )
+            }
+
+            if force {
+                let providerBooks = await books.books(
+                    source: Book.BookSource.booklore.rawValue, providerId: providerId, mediaType: "ebook"
+                )
+                for book in providerBooks where !absorbedIds.contains(book.stableId) {
+                    if seenStableIds.insert(book.stableId).inserted { prioritizedBooks.append(book) }
+                }
             }
 
             let extraConflictLimit = (launchOptimized && totalEligible > 5_000) ? 4 : 12
@@ -165,9 +179,9 @@ final class BookloreEbookSyncStrategy: ProviderSyncStrategy {
                 let diagnosticID = DiagnosticLogSanitizer.identifier(for: book.stableId)
                 if Task.isCancelled {
                     AppLogger.sync.debug("Booklore ebook sync cancelled bookDiagnosticID=\(diagnosticID)")
-                    return ProviderSyncResult(pulled: pullCount, pushed: pushCount)
+                    return ProviderSyncResult(pulled: pullCount, pushed: pushCount, failedBackends: failedBackends, wasCancelled: true)
                 }
-                guard book.stableId != playingBookId else { continue }
+                guard book.stableId != playingBookId, PendingSyncQueueStore.shared.entries[book.stableId] == nil else { continue }
 
                 do {
                     let localProgress = book.ebookProgress ?? 0
@@ -175,7 +189,7 @@ final class BookloreEbookSyncStrategy: ProviderSyncStrategy {
 
                     guard let serverResult = try await provider.fetchEbookProgressState(for: book) else {
                         guard localProgress > 0.001 else { continue }
-                        try? await provider.updateEbookProgress(for: book, progress: localProgress, epubLocator: book.epubLocator)
+                        try await provider.updateEbookProgress(for: book, progress: localProgress, epubLocator: book.epubLocator)
                         AppLogger.sync.info(
                             "Pushed Booklore ebook progress to empty server state bookDiagnosticID=\(diagnosticID) progress=\(Int(localProgress * 100))%"
                         )
@@ -267,7 +281,7 @@ final class BookloreEbookSyncStrategy: ProviderSyncStrategy {
                         )
                         pullCount += 1
                     case .push:
-                        try? await provider.updateEbookProgress(for: book, progress: localProgress, epubLocator: book.epubLocator)
+                        try await provider.updateEbookProgress(for: book, progress: localProgress, epubLocator: book.epubLocator)
                         AppLogger.sync.debug(
                             "Pushed Booklore ebook progress bookDiagnosticID=\(diagnosticID) progress=\(Int(localProgress * 100))%"
                         )
@@ -290,6 +304,10 @@ final class BookloreEbookSyncStrategy: ProviderSyncStrategy {
                         break
                     }
                 } catch {
+                    if error is CancellationError || (error as? URLError)?.code == .cancelled {
+                        return ProviderSyncResult(pulled: pullCount, pushed: pushCount, failedBackends: failedBackends, wasCancelled: true)
+                    }
+                    if !failedBackends.contains(provider.connection.name) { failedBackends.append(provider.connection.name) }
                     AppLogger.sync.error(
                         "Failed to sync Booklore ebook bookDiagnosticID=\(diagnosticID): \(String(reflecting: error))"
                     )
@@ -301,6 +319,6 @@ final class BookloreEbookSyncStrategy: ProviderSyncStrategy {
             await bookWriter.upsertBooks(updatedInMemoryBooks)
         }
 
-        return ProviderSyncResult(pulled: pullCount, pushed: pushCount)
+        return ProviderSyncResult(pulled: pullCount, pushed: pushCount, failedBackends: failedBackends)
     }
 }

--- a/ios/enve/Services/Sync/KomgaEbookSyncStrategy.swift
+++ b/ios/enve/Services/Sync/KomgaEbookSyncStrategy.swift
@@ -38,6 +38,7 @@ final class KomgaEbookSyncStrategy: ProviderSyncStrategy {
         guard !connections.isEmpty else { return .zero }
 
         var pulled = 0
+        var failedBackends: [String] = []
 
         for connection in connections {
             guard let provider = providerConnections.provider(for: connection.id) as? KomgaProvider else { continue }
@@ -58,6 +59,7 @@ final class KomgaEbookSyncStrategy: ProviderSyncStrategy {
                 for progress in progressItems {
                     guard let book = localBooksById[progress.libraryItemId],
                         book.stableId != activeBookId,
+                        PendingSyncQueueStore.shared.entries[book.stableId] == nil,
                         let serverProgress = progress.ebookProgress
                     else { continue }
 
@@ -94,9 +96,25 @@ final class KomgaEbookSyncStrategy: ProviderSyncStrategy {
 
                 for book in localBooks
                 where
-                    book.stableId != activeBookId && book.canonicalEbookProgress > 0.001 && progressByBookId[book.id] == nil
+                    book.stableId != activeBookId && PendingSyncQueueStore.shared.entries[book.stableId] == nil
+                    && (force || book.canonicalEbookProgress > 0.001) && progressByBookId[book.id] == nil
                 {
-                    guard try await provider.fetchEbookProgress(for: book) == nil else { continue }
+                    if let remote = try await provider.fetchEbookProgress(for: book) {
+                        guard force, remote.progress != book.ebookProgress || (remote.progress >= 0.99) != book.isFinished else { continue }
+                        var updated = book
+                        updated.ebookProgress = remote.progress
+                        updated.isFinished = remote.progress >= 0.99
+                        updated.serverReadStatus = updated.isFinished ? "READ" : "IN_PROGRESS"
+                        updated.hideFromContinue = false
+                        updated.lastUpdate = remote.updatedAt ?? book.lastUpdate
+                        updated.epubLocator = nil
+                        if AppState.shared.mutateBook(stableId: book.stableId, { $0 = updated }) == nil {
+                            await bookWriter.upsertBooks([updated])
+                        }
+                        pulled += 1
+                        continue
+                    }
+                    guard book.canonicalEbookProgress > 0 || book.isFinished else { continue }
 
                     let resetDate = Date()
                     var resetBook = book
@@ -118,12 +136,16 @@ final class KomgaEbookSyncStrategy: ProviderSyncStrategy {
                     pulled += 1
                 }
             } catch {
+                if error is CancellationError || (error as? URLError)?.code == .cancelled {
+                    return ProviderSyncResult(pulled: pulled, pushed: 0, failedBackends: failedBackends, wasCancelled: true)
+                }
+                if !failedBackends.contains(connection.name) { failedBackends.append(connection.name) }
                 AppLogger.sync.error(
                     "Failed to sync Komga progress providerDiagnosticID=\(DiagnosticLogSanitizer.identifier(for: connection.id.uuidString)): \(error.localizedDescription)"
                 )
             }
         }
 
-        return ProviderSyncResult(pulled: pulled, pushed: 0)
+        return ProviderSyncResult(pulled: pulled, pushed: 0, failedBackends: failedBackends)
     }
 }

--- a/ios/enve/Services/Sync/LinkedBookPassageService.swift
+++ b/ios/enve/Services/Sync/LinkedBookPassageService.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+enum LinkedBookPassageError: LocalizedError {
+    case downloadRequired
+    case noMatch
+
+    var errorDescription: String? {
+        switch self {
+        case .downloadRequired:
+            return "Download the audiobook and linked ebook before finding a passage."
+        case .noMatch:
+            return "No confident, unique match was found. Your position has not changed. Try a nearby passage with more spoken words."
+        }
+    }
+}
+
+@MainActor
+enum LinkedBookPassageService {
+    @available(iOS 26.0, *)
+    static func find(ebook: Book, audiobook: Book, at position: TimeInterval) async throws -> LinkedBookSparseMatcher.Match {
+        guard LocalStorageManager.shared.localAudiobookFilesIfExists(for: audiobook)?.isEmpty == false,
+            UnifiedDownloadService.shared.existingReaderAsset(for: ebook) != nil
+        else { throw LinkedBookPassageError.downloadRequired }
+
+        try await EbookContextService.shared.prepareContext(for: ebook)
+        try Task.checkCancellation()
+        guard let context = EbookContextStore.shared.loadContext(bookStableId: ebook.stableId) else {
+            throw LinkedBookPassageError.noMatch
+        }
+        let tracks = try await AudiobookAudioTimelineResolver.shared.localTracks(for: audiobook)
+        guard tracks.totalDuration > 0, position.isFinite else { throw LinkedBookPassageError.noMatch }
+        let center = min(max(position, 0), tracks.totalDuration)
+        let segments = try await AudiobookTranscriptionService.shared.transcribeWindow(
+            for: audiobook, startTime: max(0, center - 12), endTime: min(tracks.totalDuration, center + 12)
+        )
+        try Task.checkCancellation()
+        guard let match = LinkedBookSparseMatcher.match(
+            transcript: segments.sorted { $0.startTime < $1.startTime }.map(\.text).joined(separator: " "),
+            expectedProgress: center / tracks.totalDuration,
+            in: LinkedBookTextIndex(chunks: context.chunks),
+            requiresUniquePassage: true
+        ), match.href?.isEmpty == false else { throw LinkedBookPassageError.noMatch }
+        return match
+    }
+
+    static func bookForOpening(_ ebook: Book, match: LinkedBookSparseMatcher.Match) throws -> Book {
+        let data = try JSONSerialization.data(withJSONObject: [
+            "href": match.href ?? "",
+            "type": "application/xhtml+xml",
+            "locations": ["totalProgression": match.ebookProgress],
+            "text": ["highlight": match.quote],
+        ])
+        var target = ebook
+        target.epubLocator = String(decoding: data, as: UTF8.self)
+        return target
+    }
+}

--- a/ios/enve/Services/Sync/LinkedBookQuickSyncService.swift
+++ b/ios/enve/Services/Sync/LinkedBookQuickSyncService.swift
@@ -344,7 +344,7 @@ final class LinkedBookQuickSyncService {
     }
 }
 
-private struct LinkedBookTextIndex {
+struct LinkedBookTextIndex {
     struct Token {
         let value: String
         let chunkIndex: Int
@@ -373,7 +373,7 @@ private struct LinkedBookTextIndex {
     }
 }
 
-private enum LinkedBookSparseMatcher {
+enum LinkedBookSparseMatcher {
     struct Match {
         let ebookProgress: Double
         let quote: String
@@ -384,7 +384,8 @@ private enum LinkedBookSparseMatcher {
     static func match(
         transcript: String,
         expectedProgress: Double,
-        in index: LinkedBookTextIndex
+        in index: LinkedBookTextIndex,
+        requiresUniquePassage: Bool = false
     ) -> Match? {
         let query = words(in: transcript)
         guard query.count >= 8 else { return nil }
@@ -428,6 +429,7 @@ private enum LinkedBookSparseMatcher {
             abs($0.centerToken - best.centerToken) > query.count
         }
         let margin = best.score - (runnerUp?.score ?? 0)
+        if requiresUniquePassage, best.score < 0.72 || margin < 0.12 { return nil }
         guard best.score >= 0.38,
             margin >= 0.025 || best.score >= 0.58
         else {
@@ -450,9 +452,13 @@ private enum LinkedBookSparseMatcher {
             1
         )
         let confidence = min(1, best.score + min(max(margin, 0), 0.15))
+        let wordRanges = chunk.text.ranges(of: /[\p{L}\p{N}]+/)
+        let quote = requiresUniquePassage && wordRanges.count == chunkWords.count
+            ? String(chunk.text[wordRanges[quoteStart].lowerBound..<wordRanges[quoteEnd - 1].upperBound])
+            : chunkWords[quoteStart..<quoteEnd].joined(separator: " ")
         return Match(
             ebookProgress: ebookProgress,
-            quote: chunkWords[quoteStart..<quoteEnd].joined(separator: " "),
+            quote: quote,
             href: chunk.href,
             confidence: confidence
         )

--- a/ios/enve/Services/Sync/NativeProgressSyncStrategy.swift
+++ b/ios/enve/Services/Sync/NativeProgressSyncStrategy.swift
@@ -1,0 +1,127 @@
+import Foundation
+
+@MainActor
+final class NativeProgressSyncStrategy: ProviderSyncStrategy {
+    var id: String { "native-\(source.rawValue)" }
+    var displayName: String { String(describing: providerType) }
+
+    private let providerType: ProviderType
+    private let source: Book.BookSource
+    private let connections: any ProviderConnectionAccessing
+    private let books: any BookQuerying
+    private let progressRepository: any ProgressRepository
+    private let libraryCache: any RecentlyPlayedLibraryCaching
+    private let progressCache: any RecentlyPlayedProgressCaching
+    private let playbackState: any PlaybackStateProvider
+    private let pendingSyncs: PendingSyncQueueStore
+
+    init(
+        providerType: ProviderType,
+        source: Book.BookSource,
+        connections: any ProviderConnectionAccessing,
+        books: any BookQuerying,
+        progressRepository: any ProgressRepository,
+        libraryCache: any RecentlyPlayedLibraryCaching,
+        progressCache: any RecentlyPlayedProgressCaching,
+        playbackState: any PlaybackStateProvider,
+        pendingSyncs: PendingSyncQueueStore = .shared
+    ) {
+        self.providerType = providerType
+        self.source = source
+        self.connections = connections
+        self.books = books
+        self.progressRepository = progressRepository
+        self.libraryCache = libraryCache
+        self.progressCache = progressCache
+        self.playbackState = playbackState
+        self.pendingSyncs = pendingSyncs
+    }
+
+    func sync(force: Bool, launchOptimized: Bool) async -> ProviderSyncResult {
+        var result = ProviderSyncResult.zero
+        let absorbed = await books.absorbedStableIds()
+        for connection in connections.activeConnections(of: providerType) {
+            guard let provider = connections.provider(for: connection.id) else {
+                result.failedBackends.append(connection.name)
+                continue
+            }
+            let localBooks = await books.books(source: source.rawValue, providerId: connection.id)
+            let candidates = localBooks.sorted { $0.lastUpdate > $1.lastUpdate }
+            for book in candidates.prefix(launchOptimized && !force ? 40 : candidates.count) {
+                guard book.stableId != playbackState.currentBook?.stableId,
+                    !absorbed.contains(book.stableId), pendingSyncs.entries[book.stableId] == nil
+                else { continue }
+                do {
+                    try Task.checkCancellation()
+                    var updated = book
+                    let serverDate: Date?
+                    if book.mediaType == .ebook {
+                        guard let pulling = provider as? any EbookProgressPulling,
+                            let progress = try await pulling.fetchEbookProgressState(for: book)
+                        else { continue }
+                        updated.ebookProgress = progress.progress
+                        if let locator = progress.locator, !locator.isEmpty {
+                            updated.epubLocator = locator
+                        } else if abs(progress.progress - (book.ebookProgress ?? 0)) > 0.005 {
+                            updated.epubLocator = nil
+                        }
+                        updated.isFinished = progress.readState.isFinished || progress.readState.isAbandoned || progress.progress >= 0.99
+                        updated.serverReadStatus = updated.isFinished ? "READ" : progress.readState.persistedStatus
+                        updated.hideFromContinue = progress.readState == .notReading
+                        serverDate = progress.updatedAt
+                    } else {
+                        guard let pulling = provider as? any AudiobookProgressPulling,
+                            let progress = try await pulling.fetchAudiobookProgressState(for: book)
+                        else { continue }
+                        updated.currentTime = progress.positionSeconds
+                        updated.isFinished = progress.readState.isFinished || progress.readState.isAbandoned || progress.percentage >= 0.99
+                        updated.serverReadStatus = updated.isFinished ? "READ" : progress.readState.persistedStatus
+                        updated.hideFromContinue = progress.readState == .notReading
+                        serverDate = progress.updatedAt
+                    }
+                    // A local edit can arrive while the provider request is suspended.
+                    guard pendingSyncs.entries[book.stableId] == nil,
+                        book.stableId != playbackState.currentBook?.stableId,
+                        let current = await books.book(uniqueId: book.uniqueId),
+                        current.lastUpdate == book.lastUpdate,
+                        current.currentTime == book.currentTime, current.ebookProgress == book.ebookProgress,
+                        current.epubLocator == book.epubLocator
+                    else { continue }
+                    guard updated.currentTime != book.currentTime || (updated.ebookProgress ?? 0) != (book.ebookProgress ?? 0)
+                        || updated.epubLocator != book.epubLocator || updated.isFinished != book.isFinished
+                        || updated.hideFromContinue != book.hideFromContinue
+                    else { continue }
+                    updated.lastUpdate = serverDate ?? book.lastUpdate
+                    await progressRepository.applyAuthoritativeProgress([
+                        AuthoritativeProgressUpdate(
+                            bookUniqueId: book.uniqueId, stableId: book.stableId,
+                            currentTime: updated.currentTime, duration: book.duration ?? 0,
+                            ebookProgress: updated.ebookProgress, epubLocator: updated.epubLocator,
+                            isFinished: updated.isFinished, lastUpdate: updated.lastUpdate,
+                            hideFromContinue: updated.hideFromContinue, serverReadStatus: updated.serverReadStatus
+                        )
+                    ])
+                    libraryCache.mutateBook(stableId: book.stableId) { $0 = updated }
+                    if book.mediaType != .ebook {
+                        progressCache.saveProgress(for: updated, progress: updated.currentTime, duration: book.duration ?? 0, at: updated.lastUpdate)
+                    }
+                    if !updated.isFinished, !updated.hideFromContinue,
+                        updated.currentTime > 0 || (updated.ebookProgress ?? 0) > 0
+                    {
+                        progressCache.saveRecentlyPlayed(updated, date: updated.lastUpdate)
+                    }
+                    result = ProviderSyncResult(pulled: result.pulled + 1, pushed: 0, failedBackends: result.failedBackends)
+                } catch {
+                    if error is CancellationError || (error as? URLError)?.code == .cancelled {
+                        result.wasCancelled = true
+                        return result
+                    }
+                    if !result.failedBackends.contains(connection.name) { result.failedBackends.append(connection.name) }
+                    if error is URLError { break }
+                    if case ProviderError.unauthorized = error { break }
+                }
+            }
+        }
+        return result
+    }
+}

--- a/ios/enve/Services/Sync/PendingSyncQueueFlusher.swift
+++ b/ios/enve/Services/Sync/PendingSyncQueueFlusher.swift
@@ -102,9 +102,12 @@ final class PendingSyncQueueFlusher {
     }
 
     private func flush(stableId: String, entry: PendingServerSync) async {
+        guard store.entries[stableId] == entry else { return }
         let diagnosticID = DiagnosticLogSanitizer.identifier(for: stableId)
         do {
-            switch try await transport.push(stableId: stableId, entry: entry) {
+            let disposition = try await transport.push(stableId: stableId, entry: entry)
+            guard store.entries[stableId] == entry else { return }
+            switch disposition {
             case .remove:
                 store.remove(stableId: stableId)
                 AppLogger.sync.debug("[PendingSync] Flushed bookDiagnosticID=\(diagnosticID)")
@@ -112,6 +115,7 @@ final class PendingSyncQueueFlusher {
                 AppLogger.sync.debug("[PendingSync] Retained bookDiagnosticID=\(diagnosticID); transport is unavailable")
             }
         } catch {
+            guard store.entries[stableId] == entry else { return }
             let status = httpStatus(from: error)
             switch status {
             case 401, 403:

--- a/ios/enve/Services/Sync/ProviderSyncSink.swift
+++ b/ios/enve/Services/Sync/ProviderSyncSink.swift
@@ -22,7 +22,7 @@ final class ProviderSyncSink: SyncSink {
             && (provider.syncCapability.contains(.pullProgress) || provider.syncCapability.contains(.pushProgress))
     }
 
-    func pull(book: Book, domain: ProgressSyncDomain) async -> SyncSnapshot? {
+    func pull(book: Book, domain: ProgressSyncDomain) async throws -> SyncSnapshot? {
         guard let provider = providerResolver.provider(for: book) else { return nil }
         guard provider.syncCapability.contains(.pullProgress) else { return nil }
         let sourceName = provider.connection.name.isEmpty ? provider.connection.type.rawValue : provider.connection.name
@@ -45,7 +45,7 @@ final class ProviderSyncSink: SyncSink {
                 )
             }
             guard let progressProvider = provider as? any EbookProgressPulling else { return nil }
-            guard let result = try? await progressProvider.fetchEbookProgressState(for: book),
+            guard let result = try await progressProvider.fetchEbookProgressState(for: book),
                 result.readState != .notReading
             else { return nil }
             return SyncSnapshot(
@@ -58,7 +58,7 @@ final class ProviderSyncSink: SyncSink {
             )
         } else {
             guard let progressProvider = provider as? any AudiobookProgressPulling else { return nil }
-            guard let result = try? await progressProvider.fetchAudiobookProgressState(for: book),
+            guard let result = try await progressProvider.fetchAudiobookProgressState(for: book),
                 result.readState != .notReading
             else { return nil }
             let dur = book.duration ?? 1
@@ -75,7 +75,7 @@ final class ProviderSyncSink: SyncSink {
     }
 
     func push(_ update: ProgressUpdate) async throws {
-        guard let provider = providerResolver.provider(for: update.book) else { return }
+        guard let provider = providerResolver.provider(for: update.book) else { throw ProviderError.invalidResponse }
         guard provider.syncCapability.contains(.pushProgress) else { return }
 
         if update.domain == .ebook {

--- a/ios/enve/Services/Sync/RecentlyPlayedSyncService.swift
+++ b/ios/enve/Services/Sync/RecentlyPlayedSyncService.swift
@@ -41,7 +41,6 @@ protocol RecentlyPlayedSyncing: AnyObject {
 
 @MainActor
 final class RecentlyPlayedSyncService: RecentlyPlayedSyncing {
-    private static let recentItemLimit = 20
     private static let snapshotRefreshBookLimit = 5_000
 
     private let playbackState: any PlaybackStateProvider
@@ -81,9 +80,9 @@ final class RecentlyPlayedSyncService: RecentlyPlayedSyncing {
 
     func sync(trigger: ServerStatusSyncTrigger) async -> ServerStatusSyncResult {
         let progressBackends = providerConnections.allBackends().filter {
-            $0.enabled && ($0.type == .audiobookshelf || $0.type == .jellyfin || $0.type == .emby)
+            $0.enabled && $0.type == .audiobookshelf
         }
-        let strategyConnectionCount = [ProviderType.booklore, .storyteller, .bookOrbit, .komga, .silo]
+        let strategyConnectionCount = [ProviderType.booklore, .storyteller, .bookOrbit, .komga, .silo, .jellyfin, .emby, .plex, .kavita]
             .reduce(0) { $0 + providerConnections.activeConnections(of: $1).count }
 
         guard !progressBackends.isEmpty || strategyConnectionCount > 0 else {
@@ -108,119 +107,166 @@ final class RecentlyPlayedSyncService: RecentlyPlayedSyncing {
                     (lhs.lastUpdate ?? 0) > (rhs.lastUpdate ?? 0)
                 }
 
-                let recent =
-                    sorted
-                    .filter { ($0.isFinished ?? false) == false && (($0.currentTime ?? 0) > 0 || ($0.ebookProgress ?? 0) > 0) }
-                    .prefix(Self.recentItemLimit)
+                let localBooks: [Book]
+                if let providerId = UUID(uuidString: backend.id) {
+                    localBooks = await bookQuerying.books(source: Book.BookSource.audiobookshelf.rawValue, providerId: providerId)
+                } else {
+                    localBooks = await bookQuerying.books(backendId: backend.id, source: Book.BookSource.audiobookshelf.rawValue)
+                }
+                let booksByItemId = Dictionary(grouping: localBooks, by: { $0.partKey ?? $0.id })
 
-                let neededIds = Set(recent.compactMap(\.libraryItemId))
-                let bookById = await bookQuerying.booksByIds(neededIds)
+                for item in sorted {
+                    try Task.checkCancellation()
+                    guard item.episodeId == nil, let libraryItemId = item.libraryItemId else { continue }
+                    for book in booksByItemId[libraryItemId] ?? [] {
+                        guard !absorbedStableIds.contains(book.stableId) else { continue }
+                        guard book.stableId != playbackState.currentBook?.stableId,
+                            PendingSyncQueueStore.shared.entries[book.stableId] == nil
+                        else { continue }
 
-                for item in recent {
-                    guard let libraryItemId = item.libraryItemId else { continue }
-                    guard let book = bookById[libraryItemId] else { continue }
-                    guard !absorbedStableIds.contains(book.stableId) else { continue }
-                    guard book.stableId != playbackState.currentBook?.stableId else { continue }
+                        let diagnosticID = DiagnosticLogSanitizer.identifier(for: book.stableId)
+                        let serverDate = item.lastUpdate.flatMap { Date(timeIntervalSince1970: $0 / 1000) } ?? .distantPast
 
-                    let diagnosticID = DiagnosticLogSanitizer.identifier(for: book.stableId)
-                    let serverDate = item.lastUpdate.flatMap { Date(timeIntervalSince1970: $0 / 1000) } ?? Date()
+                        if book.mediaType == .ebook {
+                            let serverEbookProgress = item.ebookProgress ?? item.progress ?? 0
+                            let serverFinished = item.resolvedIsFinished
+                            let localEbookProgress = book.ebookProgress ?? 0
 
-                    if book.mediaType == .ebook {
-                        let serverEbookProgress = item.ebookProgress ?? item.progress ?? 0
-                        let localEbookProgress = book.ebookProgress ?? 0
-
-                        let direction = resolveProgressConflict(
-                            localPosition: localEbookProgress,
-                            localDate: book.lastUpdate,
-                            serverPosition: serverEbookProgress,
-                            serverDate: serverDate
-                        )
-
-                        switch direction {
-                        case .pull:
-                            await progressRepository.updateEbookProgress(
-                                uniqueId: book.uniqueId,
-                                ebookProgress: serverEbookProgress,
-                                epubLocator: nil,
-                                isFinished: serverEbookProgress >= 0.99,
-                                lastUpdate: serverDate
+                            var direction = resolveProgressConflict(
+                                localPosition: localEbookProgress,
+                                localDate: book.lastUpdate,
+                                serverPosition: serverEbookProgress,
+                                serverDate: serverDate
                             )
-                            libraryCache.mutateBook(stableId: book.stableId) {
-                                $0.ebookProgress = serverEbookProgress
-                                $0.lastUpdate = serverDate
+
+                            if serverDate > book.lastUpdate, serverEbookProgress == 0, localEbookProgress > 0 {
+                                direction = .pull
                             }
-                            ebookLinks.saveLinks()
-                            AppLogger.sync.debug(
-                                "Pulled ebook progress bookDiagnosticID=\(diagnosticID) progress=\(Int(serverEbookProgress * 100))%"
-                            )
-                            pullCount += 1
-                        case .push:
-                            do {
-                                try await progressAPI.pushEbookProgress(
-                                    libraryItemId: book.partKey ?? book.id,
-                                    progress: localEbookProgress,
-                                    isFinished: localEbookProgress >= 0.99,
-                                    backend: backend
+                            if direction == .none, serverDate >= book.lastUpdate, book.isFinished != serverFinished {
+                                direction = .pull
+                            }
+                            switch direction {
+                            case .pull:
+                                await progressRepository.updateEbookProgress(
+                                    uniqueId: book.uniqueId,
+                                    ebookProgress: serverEbookProgress,
+                                    epubLocator: nil,
+                                    isFinished: serverFinished,
+                                    lastUpdate: serverDate
                                 )
+                                libraryCache.mutateBook(stableId: book.stableId) {
+                                    $0.ebookProgress = serverEbookProgress
+                                    $0.isFinished = serverFinished
+                                    $0.epubLocator = nil
+                                    $0.lastUpdate = serverDate
+                                }
+                                ebookLinks.saveLinks()
                                 AppLogger.sync.debug(
-                                    "Pushed ebook progress bookDiagnosticID=\(diagnosticID) progress=\(Int(localEbookProgress * 100))%"
+                                    "Pulled ebook progress bookDiagnosticID=\(diagnosticID) progress=\(Int(serverEbookProgress * 100))%"
                                 )
-                                pushCount += 1
-                            } catch {
-                                AppLogger.sync.error(
-                                    "Failed to push ebook progress bookDiagnosticID=\(diagnosticID): \(error.localizedDescription)"
-                                )
+                                pullCount += 1
+                            case .push:
+                                do {
+                                    try await progressAPI.pushEbookProgress(
+                                        libraryItemId: book.partKey ?? book.id,
+                                        progress: localEbookProgress,
+                                        isFinished: localEbookProgress >= 0.99,
+                                        backend: backend
+                                    )
+                                    AppLogger.sync.debug(
+                                        "Pushed ebook progress bookDiagnosticID=\(diagnosticID) progress=\(Int(localEbookProgress * 100))%"
+                                    )
+                                    pushCount += 1
+                                } catch {
+                                    if error is CancellationError || (error as? URLError)?.code == .cancelled { throw error }
+                                    if !failedBackends.contains(backend.name) { failedBackends.append(backend.name) }
+                                    AppLogger.sync.error(
+                                        "Failed to push ebook progress bookDiagnosticID=\(diagnosticID): \(error.localizedDescription)"
+                                    )
+                                }
+                            case .none, .conflict:
+                                break
                             }
-                        case .none, .conflict:
-                            break
+                        } else {
+                            let serverTime = item.currentTime ?? 0
+                            let duration = item.duration ?? book.duration ?? 0
+
+                            let local = progressCache.loadProgress(for: book)
+                            let localTime = local?.progress ?? book.currentTime
+                            let localDate = local.flatMap { Date(timeIntervalSince1970: $0.lastUpdated) } ?? book.lastUpdate
+
+                            var direction = resolveProgressConflict(
+                                localPosition: localTime,
+                                localDate: localDate,
+                                serverPosition: serverTime,
+                                serverDate: serverDate
+                            )
+
+                            let serverFinished = item.resolvedIsFinished
+                            if serverDate > localDate, serverTime == 0, localTime > 0 {
+                                direction = .pull
+                            }
+                            if direction == .none, serverDate >= localDate, book.isFinished != serverFinished {
+                                direction = .pull
+                            }
+                            switch direction {
+                            case .pull:
+                                progressCache.saveProgress(for: book, progress: serverTime, duration: duration, at: serverDate)
+                                await progressRepository.applyAuthoritativeProgress([
+                                    AuthoritativeProgressUpdate(
+                                        bookUniqueId: book.uniqueId,
+                                        stableId: book.stableId,
+                                        currentTime: serverTime,
+                                        duration: duration,
+                                        ebookProgress: book.ebookProgress,
+                                        epubLocator: book.epubLocator,
+                                        isFinished: serverFinished,
+                                        lastUpdate: serverDate,
+                                        hideFromContinue: item.hideFromContinueListening ?? false
+                                    )
+                                ])
+                                libraryCache.mutateBook(stableId: book.stableId) {
+                                    $0.currentTime = serverTime
+                                    $0.isFinished = serverFinished
+                                    $0.lastUpdate = serverDate
+                                    $0.hideFromContinue = item.hideFromContinueListening ?? false
+                                }
+                                AppLogger.sync.debug(
+                                    "Pulled audiobook progress bookDiagnosticID=\(diagnosticID) position=\(Int(serverTime))s"
+                                )
+                                pullCount += 1
+                            case .push:
+                                do {
+                                    let localDuration = local?.duration ?? duration
+                                    try await progressAPI.pushAudiobookProgress(
+                                        libraryItemId: book.partKey ?? book.id,
+                                        currentTime: localTime,
+                                        duration: localDuration,
+                                        isFinished: localDuration > 0 && localTime >= localDuration,
+                                        backend: backend
+                                    )
+                                    AppLogger.sync.debug(
+                                        "Pushed audiobook progress bookDiagnosticID=\(diagnosticID) position=\(Int(localTime))s"
+                                    )
+                                    pushCount += 1
+                                } catch {
+                                    if error is CancellationError || (error as? URLError)?.code == .cancelled { throw error }
+                                    if !failedBackends.contains(backend.name) { failedBackends.append(backend.name) }
+                                    AppLogger.sync.error(
+                                        "Failed to push audiobook progress bookDiagnosticID=\(diagnosticID): \(error.localizedDescription)"
+                                    )
+                                }
+                            case .none, .conflict:
+                                break
+                            }
                         }
-                    } else {
-                        let serverTime = item.currentTime ?? 0
-                        let duration = item.duration ?? book.duration ?? 0
 
-                        let local = progressCache.loadProgress(for: book)
-                        let localTime = local?.progress ?? 0
-                        let localDate = local.flatMap { Date(timeIntervalSince1970: $0.lastUpdated) } ?? .distantPast
-
-                        let direction = resolveProgressConflict(
-                            localPosition: localTime,
-                            localDate: localDate,
-                            serverPosition: serverTime,
-                            serverDate: serverDate
-                        )
-
-                        switch direction {
-                        case .pull:
-                            progressCache.saveProgress(for: book, progress: serverTime, duration: duration, at: Date())
-                            AppLogger.sync.debug(
-                                "Pulled audiobook progress bookDiagnosticID=\(diagnosticID) position=\(Int(serverTime))s"
-                            )
-                            pullCount += 1
-                        case .push:
-                            do {
-                                let localDuration = local?.duration ?? duration
-                                try await progressAPI.pushAudiobookProgress(
-                                    libraryItemId: book.partKey ?? book.id,
-                                    currentTime: localTime,
-                                    duration: localDuration,
-                                    isFinished: localDuration > 0 && localTime >= localDuration,
-                                    backend: backend
-                                )
-                                AppLogger.sync.debug(
-                                    "Pushed audiobook progress bookDiagnosticID=\(diagnosticID) position=\(Int(localTime))s"
-                                )
-                                pushCount += 1
-                            } catch {
-                                AppLogger.sync.error(
-                                    "Failed to push audiobook progress bookDiagnosticID=\(diagnosticID): \(error.localizedDescription)"
-                                )
-                            }
-                        case .none, .conflict:
-                            break
+                        if !item.resolvedIsFinished, item.hideFromContinueListening != true,
+                            (item.currentTime ?? 0) > 0 || (item.ebookProgress ?? 0) > 0
+                        {
+                            progressCache.saveRecentlyPlayed(book, date: serverDate)
                         }
                     }
-
-                    progressCache.saveRecentlyPlayed(book, date: serverDate)
                 }
             } catch is CancellationError {
                 AppLogger.sync.debug("Server status sync cancelled")
@@ -243,7 +289,7 @@ final class RecentlyPlayedSyncService: RecentlyPlayedSyncing {
         let strategies = strategyRegistry.syncStrategies
         await libraryCache.withAllBooksTransaction {
             for strategy in strategies {
-                if Task.isCancelled {
+                if wasCancelled || Task.isCancelled {
                     AppLogger.sync.info("Server status sync cancelled before strategy \(strategy.id)")
                     wasCancelled = true
                     break
@@ -251,6 +297,8 @@ final class RecentlyPlayedSyncService: RecentlyPlayedSyncing {
                 let result = await strategy.sync(force: force, launchOptimized: launchOptimized)
                 pullCount += result.pulled
                 pushCount += result.pushed
+                failedBackends.append(contentsOf: result.failedBackends.filter { !failedBackends.contains($0) })
+                wasCancelled = wasCancelled || result.wasCancelled
             }
         }
 

--- a/ios/enve/Services/Sync/SiloActivitySyncStrategy.swift
+++ b/ios/enve/Services/Sync/SiloActivitySyncStrategy.swift
@@ -35,6 +35,7 @@ final class SiloActivitySyncStrategy: ProviderSyncStrategy {
         guard !connections.isEmpty else { return .zero }
 
         var pulled = 0
+        var failedBackends: [String] = []
         let pushed = 0
 
         for connection in connections {
@@ -73,9 +74,11 @@ final class SiloActivitySyncStrategy: ProviderSyncStrategy {
                         )
                     }
                 }
-            } catch is CancellationError {
-                return ProviderSyncResult(pulled: pulled, pushed: pushed)
             } catch {
+                if error is CancellationError || (error as? URLError)?.code == .cancelled {
+                    return ProviderSyncResult(pulled: pulled, pushed: pushed, failedBackends: failedBackends, wasCancelled: true)
+                }
+                if !failedBackends.contains(connection.name) { failedBackends.append(connection.name) }
                 AppLogger.sync.error(
                     "Silo activity sync failed providerDiagnosticID=\(DiagnosticLogSanitizer.identifier(for: connection.id.uuidString)): \(error.localizedDescription)"
                 )
@@ -88,7 +91,7 @@ final class SiloActivitySyncStrategy: ProviderSyncStrategy {
                 object: nil
             )
         }
-        return ProviderSyncResult(pulled: pulled, pushed: pushed)
+        return ProviderSyncResult(pulled: pulled, pushed: pushed, failedBackends: failedBackends)
     }
 
     private func pullCursorDeltas(

--- a/ios/enve/Services/Sync/SiloEbookSyncStrategy.swift
+++ b/ios/enve/Services/Sync/SiloEbookSyncStrategy.swift
@@ -41,6 +41,7 @@ final class SiloEbookSyncStrategy: ProviderSyncStrategy {
         guard !connections.isEmpty else { return .zero }
 
         var pulled = 0
+        var failedBackends: [String] = []
         var pushed = 0
         var updatedBooks: [Book] = []
 
@@ -49,19 +50,24 @@ final class SiloEbookSyncStrategy: ProviderSyncStrategy {
             do {
                 _ = try await provider.fetchLibraries()
             } catch {
+                if error is CancellationError || (error as? URLError)?.code == .cancelled {
+                    return ProviderSyncResult(pulled: pulled, pushed: pushed, failedBackends: failedBackends, wasCancelled: true)
+                }
+                if !failedBackends.contains(connection.name) { failedBackends.append(connection.name) }
                 AppLogger.sync.debug(
                     "Skipping Silo ebook sync providerDiagnosticID=\(DiagnosticLogSanitizer.identifier(for: connection.id.uuidString)): \(error.localizedDescription)"
                 )
                 continue
             }
 
-            let candidateBooks = await books.firstBooks(
+            let candidateBooks = await books.books(
                 source: Book.BookSource.silo.rawValue,
-                mediaType: "ebook",
-                limit: launchOptimized ? 100 : 1000
-            ).filter { $0.providerId == connection.id }
+                providerId: connection.id,
+                mediaType: "ebook"
+            ).sorted { $0.lastUpdate > $1.lastUpdate }
 
-            for book in candidateBooks where book.stableId != activeBookId {
+            for book in candidateBooks.prefix(launchOptimized && !force ? 100 : candidateBooks.count)
+            where book.stableId != activeBookId && PendingSyncQueueStore.shared.entries[book.stableId] == nil {
                 do {
                     let localProgress = book.ebookProgress ?? book.canonicalEbookProgress
                     let localDate = book.lastUpdate
@@ -153,6 +159,10 @@ final class SiloEbookSyncStrategy: ProviderSyncStrategy {
                         break
                     }
                 } catch {
+                    if error is CancellationError || (error as? URLError)?.code == .cancelled {
+                        return ProviderSyncResult(pulled: pulled, pushed: pushed, failedBackends: failedBackends, wasCancelled: true)
+                    }
+                    if !failedBackends.contains(connection.name) { failedBackends.append(connection.name) }
                     AppLogger.sync.error(
                         "Failed to sync Silo ebook bookDiagnosticID=\(DiagnosticLogSanitizer.identifier(for: book.stableId)): \(error.localizedDescription)"
                     )
@@ -164,6 +174,6 @@ final class SiloEbookSyncStrategy: ProviderSyncStrategy {
             await bookWriter.upsertBooks(updatedBooks)
         }
 
-        return ProviderSyncResult(pulled: pulled, pushed: pushed)
+        return ProviderSyncResult(pulled: pulled, pushed: pushed, failedBackends: failedBackends)
     }
 }

--- a/ios/enve/Services/Sync/StorytellerSyncStrategy.swift
+++ b/ios/enve/Services/Sync/StorytellerSyncStrategy.swift
@@ -37,6 +37,7 @@ final class StorytellerSyncStrategy: ProviderSyncStrategy {
         guard !connections.isEmpty else { return .zero }
 
         var pulled = 0
+        var failedBackends: [String] = []
         var pushed = 0
         var catalogChanged = false
 
@@ -71,7 +72,7 @@ final class StorytellerSyncStrategy: ProviderSyncStrategy {
 
                 for remoteBook in remoteBooks {
                     if Task.isCancelled {
-                        return ProviderSyncResult(pulled: pulled, pushed: pushed)
+                        return ProviderSyncResult(pulled: pulled, pushed: pushed, failedBackends: failedBackends, wasCancelled: true)
                     }
                     guard let localBook = localById[remoteBook.id],
                         !pendingIds.uniqueIds.contains(localBook.uniqueId),
@@ -88,6 +89,10 @@ final class StorytellerSyncStrategy: ProviderSyncStrategy {
                             through: provider
                         )
                     } catch {
+                        if error is CancellationError || (error as? URLError)?.code == .cancelled {
+                            return ProviderSyncResult(pulled: pulled, pushed: pushed, failedBackends: failedBackends, wasCancelled: true)
+                        }
+                        if !failedBackends.contains(connection.name) { failedBackends.append(connection.name) }
                         AppLogger.sync.error(
                             "Storyteller pending position could not be reconciled bookDiagnosticID=\(DiagnosticLogSanitizer.identifier(for: remoteBook.stableId)): \(error.localizedDescription)"
                         )
@@ -122,9 +127,11 @@ final class StorytellerSyncStrategy: ProviderSyncStrategy {
                     fingerprint: activityFingerprint(remoteBooks),
                     itemCount: remoteBooks.count
                 )
-            } catch is CancellationError {
-                return ProviderSyncResult(pulled: pulled, pushed: pushed)
             } catch {
+                if error is CancellationError || (error as? URLError)?.code == .cancelled {
+                    return ProviderSyncResult(pulled: pulled, pushed: pushed, failedBackends: failedBackends, wasCancelled: true)
+                }
+                if !failedBackends.contains(connection.name) { failedBackends.append(connection.name) }
                 AppLogger.sync.error(
                     "Storyteller mirror sync failed providerDiagnosticID=\(DiagnosticLogSanitizer.identifier(for: connection.id.uuidString)): \(error.localizedDescription)"
                 )
@@ -134,7 +141,7 @@ final class StorytellerSyncStrategy: ProviderSyncStrategy {
         if pulled > 0 || catalogChanged {
             NotificationCenter.default.post(name: .continueListeningNeedsRefresh, object: nil)
         }
-        return ProviderSyncResult(pulled: pulled, pushed: pushed)
+        return ProviderSyncResult(pulled: pulled, pushed: pushed, failedBackends: failedBackends)
     }
 
     private func reconcileCatalog(

--- a/ios/enve/Services/Sync/SyncCoordinator.swift
+++ b/ios/enve/Services/Sync/SyncCoordinator.swift
@@ -246,7 +246,9 @@ final class SyncCoordinator {
         let token = activeRecentlyPlayedSyncToken
         beginSync()
 
+        let pendingPushes = Array(pushDebounceTasks.values)
         let task = Task<ServerStatusSyncResult, Never> { @MainActor [pendingSyncFlusher, recentlyPlayedSync] in
+            for push in pendingPushes { await push.value }
             await pendingSyncFlusher.flush()
             return await recentlyPlayedSync.sync(trigger: trigger)
         }
@@ -293,29 +295,11 @@ final class SyncCoordinator {
             return
         }
 
-        guard let book = AppState.shared.bookInMemory(stableId: bookStableId),
-            let provider = providerResolver.provider(for: book)
-        else { return }
-        let localProgress = book.canonicalEbookProgress
-        let locator = book.epubLocator
+        guard var book = AppState.shared.bookInMemory(stableId: bookStableId) else { return }
+        book.lastUpdate = Date()
+        let resolvedBook = book
         Task {
-            if book.isStorytellerReadAloud,
-                let storyteller = provider as? StorytellerProvider
-            {
-                guard let locator else { return }
-                _ = try? await StorytellerPositionSyncService.shared.submit(
-                    book: book,
-                    locatorJSON: locator,
-                    observedAt: book.lastUpdate,
-                    through: storyteller
-                )
-            } else {
-                try? await (provider as? any EbookProgressPushing)?.updateEbookProgress(
-                    for: book,
-                    progress: localProgress,
-                    epubLocator: locator
-                )
-            }
+            await pushProgress(book: resolvedBook, forceImmediate: true, domain: .ebook)
         }
     }
 
@@ -330,17 +314,20 @@ final class SyncCoordinator {
         emit(.pullStarted(bookId: bookId))
 
         if book.isStorytellerReadAloud && domain.usesEbookProgress {
-            guard !excludingProvider,
-                let sink = PluginRegistry.shared
-                    .sinks(applicableTo: book, domain: domain)
-                    .first(where: { $0.id == ProviderSyncSink.identifier }),
-                let snapshot = await sink.pull(book: book, domain: domain)
-            else {
-                emit(.pullCompleted(bookId: bookId, applied: false))
-                return
+            do {
+                guard !excludingProvider,
+                    let sink = PluginRegistry.shared.sinks(applicableTo: book, domain: domain)
+                        .first(where: { $0.id == ProviderSyncSink.identifier }),
+                    let snapshot = try await sink.pull(book: book, domain: domain)
+                else {
+                    emit(.pullCompleted(bookId: bookId, applied: false))
+                    return
+                }
+                await applySnapshot(snapshot, to: book, usesEbookProgress: true)
+                emit(.pullCompleted(bookId: bookId, applied: true))
+            } catch {
+                emit(.pullFailed(bookId: bookId, error: error.localizedDescription))
             }
-            await applySnapshot(snapshot, to: book, usesEbookProgress: true)
-            emit(.pullCompleted(bookId: bookId, applied: true))
             return
         }
 
@@ -349,8 +336,13 @@ final class SyncCoordinator {
         }
         var snapshots: [SyncSnapshot] = []
         for sink in sinks {
-            if let snap = await sink.pull(book: book, domain: domain) {
-                snapshots.append(snap)
+            do {
+                if let snap = try await sink.pull(book: book, domain: domain) {
+                    snapshots.append(snap)
+                }
+            } catch {
+                emit(.pullFailed(bookId: bookId, error: error.localizedDescription))
+                return
             }
         }
 
@@ -429,6 +421,7 @@ final class SyncCoordinator {
         let bookId = book.stableId
 
         if forceImmediate {
+            pushDebounceTasks.removeValue(forKey: bookId)?.cancel()
             await performPush(book: book, sourceEngine: sourceEngine, domain: domain)
             return
         }
@@ -626,7 +619,7 @@ final class SyncCoordinator {
     private func emit(_ event: SyncEvent) {
         let bookId: String
         switch event {
-        case .pullStarted(let id), .pullCompleted(let id, _),
+        case .pullStarted(let id), .pullCompleted(let id, _), .pullFailed(let id, _),
             .pushStarted(let id), .pushCompleted(let id), .pushFailed(let id, _, _),
             .conflictDetected(let id, _, _, _):
             bookId = id

--- a/ios/enve/Services/Sync/SyncEvent.swift
+++ b/ios/enve/Services/Sync/SyncEvent.swift
@@ -2,6 +2,7 @@ import Foundation
 
 enum SyncEvent: Sendable {
     case pullStarted(bookId: String)
+    case pullFailed(bookId: String, error: String)
     case pullCompleted(bookId: String, applied: Bool)
     case pushStarted(bookId: String)
     case pushCompleted(bookId: String)

--- a/ios/enve/Utilities/NetworkHostUtils.swift
+++ b/ios/enve/Utilities/NetworkHostUtils.swift
@@ -4,21 +4,22 @@ import Foundation
 
 enum NetworkHostUtils {
     static nonisolated func isLocalNetworkHost(_ host: String) -> Bool {
-        if host == "localhost" || host == "127.0.0.1" { return true }
-        if host.hasPrefix("192.168.") || host.hasPrefix("10.") { return true }
-
-        if host.hasPrefix("172."),
-            let second = host.split(separator: ".").dropFirst().first,
-            let v = Int(second), (16...31).contains(v)
+        if host == "localhost" { return true }
+        let parts = host.split(separator: ".", omittingEmptySubsequences: false)
+        if parts.count == 4,
+            parts.allSatisfy({ part in
+                !part.isEmpty && (part.count == 1 || part.first != "0")
+                    && part.utf8.allSatisfy { (48...57).contains($0) }
+            })
         {
-            return true
-        }
-
-        if host.hasPrefix("100."),
-            let second = host.split(separator: ".").dropFirst().first,
-            let v = Int(second), (64...127).contains(v)
-        {
-            return true
+            let octets = parts.compactMap { UInt8($0) }
+            if octets.count == 4 {
+                return octets == [127, 0, 0, 1]
+                    || octets[0] == 10
+                    || (octets[0] == 192 && octets[1] == 168)
+                    || (octets[0] == 172 && (16...31).contains(octets[1]))
+                    || (octets[0] == 100 && (64...127).contains(octets[1]))
+            }
         }
 
         if host.hasSuffix(".local") || host.hasSuffix(".lan") { return true }

--- a/ios/enveTests/AuthenticationStorageTests.swift
+++ b/ios/enveTests/AuthenticationStorageTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Testing
+
+@testable import enve
+
+@MainActor
+struct AuthenticationStorageTests {
+    @Test func publicHostnamesDoNotInheritPrivateIPTrust() {
+        for host in ["10.example.com", "192.168.example.com", "172.16.example.com", "100.64.example.com", "10.0.0.1.example.com", "10.999.0.1", "010.0.0.1", "10.0.0.01", "172.16.0", "192.168.0.1."] {
+            #expect(!NetworkHostUtils.isLocalNetworkHost(host), "Unexpected local trust: \(host)")
+        }
+        for host in ["localhost", "127.0.0.1", "10.0.0.1", "192.168.255.255", "172.16.0.1", "172.31.255.255", "100.64.0.1", "100.127.255.255", "books.local"] {
+            #expect(NetworkHostUtils.isLocalNetworkHost(host), "Missing local trust: \(host)")
+        }
+        for host in ["172.15.0.1", "172.32.0.1", "100.63.0.1", "100.128.0.1", "192.169.0.1", "8.8.8.8"] {
+            #expect(!NetworkHostUtils.isLocalNetworkHost(host))
+        }
+    }
+
+    @Test func persistedOAuthTokenRetainsExpiration() throws {
+        let issuedAt = Date(timeIntervalSince1970: 1_600_000_000)
+        let token = OAuthToken(accessToken: "test", refreshToken: "refresh", expiresIn: 3600, tokenType: "Bearer", scope: nil, issuedAt: issuedAt)
+        let decoded = try JSONDecoder().decode(OAuthToken.self, from: JSONEncoder().encode(token))
+        #expect(decoded.issuedAt == issuedAt)
+        #expect(decoded.expiresAt == issuedAt.addingTimeInterval(3600))
+        #expect(decoded.isExpired)
+    }
+
+    @Test func freshOAuthResponseUsesReceiptTime() throws {
+        let before = Date()
+        let token = try JSONDecoder().decode(OAuthToken.self, from: Data(#"{"access_token":"test","token_type":"Bearer","expires_in":3600}"#.utf8))
+        #expect(token.issuedAt >= before)
+        #expect(!token.isExpired)
+    }
+
+    @Test func tokenFormPreservesReservedCharacters() {
+        let body = OAuthManager.formEncodedBody(["refresh_token": "a+b&c=d% e/é", "grant_type": "refresh_token"])
+        #expect(String(decoding: body, as: UTF8.self) == "grant_type=refresh_token&refresh_token=a%2Bb%26c%3Dd%25%20e%2F%C3%A9")
+    }
+
+    @Test func keychainHelperReplacesExistingValue() {
+        let key = "audit-test-\(UUID().uuidString)"
+        defer { KeychainHelper.shared.delete(key) }
+        KeychainHelper.shared.set("first", key: key)
+        #expect(KeychainHelper.shared.get(key) == "first")
+        KeychainHelper.shared.set("second", key: key)
+        #expect(KeychainHelper.shared.get(key) == "second")
+    }
+
+    @Test func secureStorageReplacesExistingValue() throws {
+        let service = "audit-test-\(UUID().uuidString)"
+        defer { try? SecureTokenStorage.shared.deleteAPIKey(forService: service) }
+        try SecureTokenStorage.shared.saveAPIKey("first", forService: service)
+        #expect(try SecureTokenStorage.shared.loadAPIKey(forService: service) == "first")
+        try SecureTokenStorage.shared.saveAPIKey("second", forService: service)
+        #expect(try SecureTokenStorage.shared.loadAPIKey(forService: service) == "second")
+    }
+}

--- a/ios/enveTests/AutoSleepPolicyTests.swift
+++ b/ios/enveTests/AutoSleepPolicyTests.swift
@@ -35,4 +35,15 @@ struct AutoSleepPolicyTests {
         let sameNight = AutoSleepPolicy.currentWindowStart(now: elevenPM, startMinutes: 22 * 60, calendar: calendar)
         #expect(sameNight == expected)
     }
+    @Test(arguments: [(3, 8), (11, 1)])
+    func daylightSavingNightKeepsOneWindow(date: (Int, Int)) {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "America/Los_Angeles")!
+        let expected = calendar.date(from: DateComponents(year: 2026, month: date.0, day: date.1, hour: 22))!
+        for hoursLater in [0.5, 1.5, 2.5, 5.5] {
+            let now = expected.addingTimeInterval(hoursLater * 3600)
+            #expect(AutoSleepPolicy.currentWindowStart(now: now, startMinutes: 22 * 60, calendar: calendar) == expected)
+        }
+    }
+
 }

--- a/ios/enveTests/BookOrbitCatalogTests.swift
+++ b/ios/enveTests/BookOrbitCatalogTests.swift
@@ -1,0 +1,112 @@
+import Foundation
+import Testing
+
+@testable import enve
+
+nonisolated private final class BookOrbitCatalogProtocol: URLProtocol, @unchecked Sendable {
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let url = request.url else { return }
+        let indices: [Any] = ["2", "2.5", 2, 2.5, NSNull(), "1–3", "0.50"]
+        var cards: [[String: Any]] = indices.enumerated().map { offset, index in
+            ["id": offset + 1, "title": "Fixture", "seriesName": "Series", "seriesIndex": index,
+             "files": [["id": offset + 1, "format": "epub", "role": "primary"]]]
+        }
+        cards.append(["id": 8, "title": "Without series index", "seriesName": "Series"])
+        let payload: Any
+        if url.path == "/api/v1/books/9/audio-progress" {
+            if request.httpMethod == "PATCH" {
+                var body = request.httpBody ?? Data()
+                if let stream = request.httpBodyStream {
+                    stream.open()
+                    defer { stream.close() }
+                    var buffer = [UInt8](repeating: 0, count: 1024)
+                    while stream.hasBytesAvailable {
+                        let count = stream.read(&buffer, maxLength: buffer.count)
+                        guard count > 0 else { break }
+                        body.append(contentsOf: buffer.prefix(count))
+                    }
+                }
+                let json = (try? JSONSerialization.jsonObject(with: body)) as? [String: Any]
+                guard json?["currentFileId"] as? Int == 91,
+                      json?["positionSeconds"] as? Double == 15,
+                      json?["percentage"] as? Double == 62.5 else {
+                    client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+                    return
+                }
+            }
+            payload = ["currentFileId": 91, "positionSeconds": 15, "percentage": 62.5]
+        } else if url.path == "/api/v1/books/9" {
+            payload = ["id": 9, "title": "Two-track audiobook", "files": [
+                ["id": 90, "format": "mp3", "role": "primary", "durationSeconds": 60],
+                ["id": 91, "format": "mp3", "role": "content", "durationSeconds": 60]
+            ]]
+        } else if url.path.hasSuffix("/books") {
+            payload = ["items": cards, "total": cards.count, "page": 0, "size": 200]
+        } else if let id = Int(url.lastPathComponent), (1...cards.count).contains(id) {
+            payload = cards[id - 1]
+        } else {
+            client?.urlProtocol(self, didFailWithError: URLError(.unsupportedURL))
+            return
+        }
+        do {
+            let data = try JSONSerialization.data(withJSONObject: payload)
+            let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil,
+                                           headerFields: ["Content-Type": "application/json"])!
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+@MainActor
+struct BookOrbitCatalogTests {
+    @Test func playerTimelinePreservesFileIdentityForProgress() async throws {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [BookOrbitCatalogProtocol.self]
+        let session = URLSession(configuration: configuration)
+        defer { session.invalidateAndCancel() }
+        let provider = BookOrbitProvider(
+            connection: ServerConnection(name: "Fixture", url: "https://bookorbit.invalid", type: .bookOrbit,
+                                         token: "fixture-token"), session: session
+        )
+        let book = try await provider.fetchFullBookDetails(bookId: "9", libraryId: "1")
+        let playback = try await provider.startPlaybackSession(for: book)
+        let playingBook = book.withPlaybackSessionTimeline(tracks: playback.audioTracks, duration: 120)
+        #expect(playingBook.audioTracks?.map(\.id) == ["90", "91"])
+        try await provider.updatePlaybackProgress(book: playingBook, sessionId: playback.sessionId,
+                                                  currentTime: 75, isFinished: false, timeListened: 0)
+        let remote = try #require(await provider.fetchAudiobookProgress(for: playingBook))
+        #expect(remote.positionSeconds == 75)
+        #expect(remote.trackIndex == 1)
+    }
+
+    @Test func importsSeriesIndicesFromCurrentAndOlderServers() async throws {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [BookOrbitCatalogProtocol.self]
+        let session = URLSession(configuration: configuration)
+        defer { session.invalidateAndCancel() }
+        let provider = BookOrbitProvider(
+            connection: ServerConnection(name: "Fixture", url: "https://bookorbit.invalid", type: .bookOrbit,
+                                         token: "fixture-token"),
+            session: session
+        )
+        let expected: [String?] = ["2", "2.5", "2", "2.5", nil, "1–3", "0.50", nil]
+        let books = try await provider.fetchBooks(libraryId: "1")
+        #expect(books.count == expected.count)
+        #expect(books.map { $0.seriesInfo?.sequence } == expected)
+        let recent = try await provider.fetchRecentBooks(libraryId: "1", limit: 10)
+        #expect(recent.map { $0.seriesInfo?.sequence } == expected.reversed())
+        for (book, sequence) in zip(books, expected) {
+            let detail = try await provider.fetchFullBookDetails(bookId: book.id, libraryId: "1")
+            #expect(detail.seriesInfo?.sequence == sequence)
+        }
+    }
+}

--- a/ios/enveTests/CarPlayPlaybackServiceTests.swift
+++ b/ios/enveTests/CarPlayPlaybackServiceTests.swift
@@ -5,6 +5,25 @@ import Testing
 @testable import enve
 
 @MainActor
+struct CarPlayInterfaceCompletionTests {
+    @Test func followUpRunsAfterSuccess() {
+        var callCount = 0
+
+        carPlayInterfaceCompletion("Test success", then: { callCount += 1 })(true, nil)
+
+        #expect(callCount == 1)
+    }
+
+    @Test func followUpRunsAfterFailure() {
+        var callCount = 0
+
+        carPlayInterfaceCompletion("Test failure", then: { callCount += 1 })(false, CarPlayTestError())
+
+        #expect(callCount == 1)
+    }
+}
+
+@MainActor
 struct CarPlayChapterResolutionTests {
     @Test func bookChaptersWinAndAreSortedByStart() {
         let fixture = Fixture()
@@ -54,6 +73,8 @@ struct CarPlayChapterResolutionTests {
         #expect(Fixture().service.chapters(for: book("one")).isEmpty)
     }
 }
+
+private struct CarPlayTestError: Error {}
 
 @MainActor
 struct CarPlayCurrentBookTests {

--- a/ios/enveTests/CoverTileTests.swift
+++ b/ios/enveTests/CoverTileTests.swift
@@ -1,0 +1,18 @@
+import CoreGraphics
+import Testing
+
+@testable import enve
+
+struct CoverTileTests {
+    @Test func audiobookArtworkUsesSquareRatio() {
+        let book = Book(id: "audio", title: "Audio", mediaType: .audiobook)
+
+        #expect(book.hearthCoverRatio == 1)
+    }
+
+    @Test func ebookArtworkUsesPortraitRatio() {
+        let book = Book(id: "ebook", title: "Ebook", mediaType: .ebook)
+
+        #expect(book.hearthCoverRatio == 1.5)
+    }
+}

--- a/ios/enveTests/HardcoverResponseDecodingTests.swift
+++ b/ios/enveTests/HardcoverResponseDecodingTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Testing
+
+@testable import enve
+
+struct HardcoverResponseDecodingTests {
+    @Test func readingMutationPreservesServerIdentity() throws {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let inserted = try decoder.decode(InsertReadSessionResponse.self, from: Data(#"{"insert_user_book_read":{"error":null,"user_book_read":{"id":71,"started_at":"2026-09-04","progress_pages":32}}}"#.utf8))
+        #expect(try inserted.createdReadId() == 71)
+        #expect(inserted.insertUserBookRead?.userBookRead?.progressPages == 32)
+
+        let updated = try decoder.decode(UpdateReadProgressResponse.self, from: Data(#"{"update_user_book_read":{"error":null,"user_book_read":{"id":71,"progress_pages":50}}}"#.utf8))
+        try updated.validate()
+        #expect(updated.updateUserBookRead?.userBookRead?.progressPages == 50)
+    }
+
+    @Test func nestedMutationErrorsCannotReportSuccess() throws {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let inserted = try decoder.decode(InsertReadSessionResponse.self, from: Data(#"{"insert_user_book_read":{"error":"Rejected","user_book_read":null}}"#.utf8))
+        #expect(throws: HardcoverError.self) { try inserted.createdReadId() }
+        let updated = try decoder.decode(UpdateReadProgressResponse.self, from: Data(#"{"update_user_book_read":{"error":"Rejected","user_book_read":null}}"#.utf8))
+        #expect(throws: HardcoverError.self) { try updated.validate() }
+        let rated = try decoder.decode(GenericUpdateResponse.self, from: Data(#"{"update_user_book":{"error":"Rejected"}}"#.utf8))
+        #expect(throws: HardcoverError.self) { try rated.validate() }
+    }
+
+    @Test func missingMutationResultsAreFailures() throws {
+        let decoder = JSONDecoder()
+        let inserted = try decoder.decode(InsertReadSessionResponse.self, from: Data("{}".utf8))
+        #expect(throws: HardcoverError.self) { try inserted.createdReadId() }
+        let updated = try decoder.decode(UpdateReadProgressResponse.self, from: Data("{}".utf8))
+        #expect(throws: HardcoverError.self) { try updated.validate() }
+        let rated = try decoder.decode(GenericUpdateResponse.self, from: Data("{}".utf8))
+        #expect(throws: HardcoverError.self) { try rated.validate() }
+    }
+}

--- a/ios/enveTests/JellyfinProgressTransportTests.swift
+++ b/ios/enveTests/JellyfinProgressTransportTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Testing
+
+@testable import enve
+
+private final class JellyfinProgressTransportStub: JellyfinProvider, @unchecked Sendable {
+    var requests: [URLRequest] = []
+    var status = 200
+
+    override func performDataTask(for request: URLRequest, retryCount: Int = 3) async throws -> (Data, URLResponse) {
+        requests.append(request)
+        let url = try #require(request.url)
+        let data = Data(#"{"Id":"book","Name":"Fixture","Type":"AudioBook","IsFolder":false,"RunTimeTicks":600000000,"Chapters":[{"Name":"One","StartPositionTicks":0},{"Name":"Two","StartPositionTicks":300000000}]}"#.utf8)
+        return (data, try #require(HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil)))
+    }
+}
+
+@MainActor
+struct JellyfinProgressTransportTests {
+    @Test func audioWritesPersistedUserDataAndReportsServerFailure() async throws {
+        let provider = makeProvider()
+        let book = Book(id: "book", title: "Fixture", source: .jellyfin, providerId: provider.connection.id)
+        try await provider.updatePlaybackProgress(book: book, sessionId: nil, currentTime: 23, isFinished: false, timeListened: 0)
+        let request = try #require(provider.requests.last)
+        #expect(request.url?.path == "/Users/user/Items/book/UserData")
+        let bodyData = try #require(request.httpBody)
+        let body = try #require(JSONSerialization.jsonObject(with: bodyData) as? [String: Any])
+        #expect(body["PlaybackPositionTicks"] as? Int == 230_000_000)
+        #expect(body["Played"] as? Bool == false)
+        #expect(body["LastPlayedDate"] as? String != nil)
+        provider.status = 500
+        await #expect(throws: (any Error).self) {
+            try await provider.updatePlaybackProgress(book: book, sessionId: nil, currentTime: 0, isFinished: false, timeListened: 0)
+        }
+    }
+
+    @Test func leafAudiobooksNeverQueryUnrelatedAudioChildren() async throws {
+        let provider = makeProvider()
+        let book = Book(id: "book", title: "Fixture", source: .jellyfin, providerId: provider.connection.id)
+        let session = try await provider.startPlaybackSession(for: book)
+        #expect(session.audioTracks.count == 1)
+        #expect(session.audioTracks.first?.duration == 60)
+        #expect(URL(string: session.audioTracks.first?.contentUrl ?? "")?.path == "/Audio/book/stream")
+        #expect(!provider.requests.contains { $0.url?.path == "/Users/user/Items" })
+    }
+
+    private func makeProvider() -> JellyfinProgressTransportStub {
+        JellyfinProgressTransportStub(connection: ServerConnection(
+            name: "Fixture", url: "https://jellyfin.example.invalid", type: .jellyfin, token: "fixture", userId: "user"
+        ))
+    }
+}

--- a/ios/enveTests/KOReaderDuplicateMappingTests.swift
+++ b/ios/enveTests/KOReaderDuplicateMappingTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Testing
+
+@testable import enve
+
+@MainActor
+struct KOReaderDuplicateMappingTests {
+    @Test func partialMD5MatchesKOReaderSampling() async throws {
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("koreader-hash-\(UUID().uuidString).epub")
+        let bytes = Data((0..<5_000).map { UInt8(($0 * 37 + 11) % 256) })
+        try bytes.write(to: fileURL, options: .atomic)
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let hash = await KOReaderSyncService.computePartialMD5(fileURL: fileURL)
+
+        #expect(hash == "bc0a36e392584120c95013be66f97b0b")
+    }
+
+    @Test func duplicatePersistedLinksRestoreWithoutTrapping() {
+        let first = KOReaderBookLink(
+            bookStableId: "ebook",
+            documentHash: "11111111111111111111111111111111",
+            isAutomatic: true,
+            lastSyncedAt: nil,
+            lastSyncedPercentage: nil
+        )
+        let latest = KOReaderBookLink(
+            bookStableId: "ebook",
+            documentHash: "22222222222222222222222222222222",
+            isAutomatic: false,
+            lastSyncedAt: Date(),
+            lastSyncedPercentage: 0.5
+        )
+
+        let restored = KOReaderSyncService.restoredLinks([first, latest])
+
+        #expect(restored.count == 1)
+        #expect(restored["ebook"] == latest)
+    }
+
+    @Test func duplicateBookBridgeKeysAreExcludedFromMatching() {
+        let first = makeBook(id: "duplicate", providerId: UUID())
+        let second = makeBook(id: "duplicate", providerId: UUID())
+        let unique = makeBook(id: "unique", providerId: UUID())
+
+        let indexed = BookBridgeMappingImporter.booksIndexedByUniqueKey(
+            [first, second, unique],
+            key: { $0.id }
+        )
+
+        #expect(indexed["duplicate"] == nil)
+        #expect(indexed["unique"]?.providerId == unique.providerId)
+    }
+
+    private func makeBook(id: String, providerId: UUID) -> Book {
+        Book(
+            id: id,
+            title: "Book \(id)",
+            source: .audiobookshelf,
+            mediaType: .audiobook,
+            providerId: providerId,
+            libraryId: "library"
+        )
+    }
+}

--- a/ios/enveTests/KavitaProgressTransportTests.swift
+++ b/ios/enveTests/KavitaProgressTransportTests.swift
@@ -1,0 +1,99 @@
+import Foundation
+import Testing
+
+@testable import enve
+
+private final class KavitaProgressTransportStub: KavitaProvider, @unchecked Sendable {
+    var requests: [URLRequest] = []
+    var progressStatus = 200
+
+    override func send(_ request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+        requests.append(request)
+        let url = try #require(request.url)
+        let data: Data
+        let status: Int
+        switch url.path {
+        case "/api/Series/v2", "/api/Series/recently-added-v2":
+            data = Data(#"[{"id":3,"name":"Fixture","libraryId":5}]"#.utf8)
+            status = 200
+        case "/api/Series/volumes":
+            data = Data(#"[{"id":7,"chapters":[{"id":11,"pages":100}]}]"#.utf8)
+            status = 200
+        case "/api/Reader/get-progress":
+            data = Data(#"{"chapterId":11,"pageNum":42,"lastModifiedUtc":"2026-08-30T18:30:00.123Z"}"#.utf8)
+            status = 200
+        default:
+            data = Data()
+            status = progressStatus
+        }
+        return (data, try #require(HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil)))
+    }
+}
+
+@MainActor
+struct KavitaProgressTransportTests {
+    @Test func catalogScopesLibraryAndUsesOneBasedQueryPagination() async throws {
+        let provider = makeProvider()
+        let source = try await provider.makeCatalogBatchSource(libraryId: "5", resumeAfter: nil, expectedSnapshotIdentifier: nil)
+        let batch = try #require(try await source.next())
+        #expect(batch.books.map(\.id) == ["3"])
+        let request = try #require(provider.requests.last)
+        #expect(request.url?.query == "pageNumber=1&pageSize=100")
+        let bodyData = try #require(request.httpBody)
+        let body = try #require(JSONSerialization.jsonObject(with: bodyData) as? [String: Any])
+        let statements = try #require(body["statements"] as? [[String: Any]])
+        #expect(statements.first?["field"] as? Int == 19)
+        #expect(statements.first?["value"] as? String == "5")
+        #expect(body["pageNumber"] == nil)
+    }
+
+    @Test func recentlyAddedRequiresPostAndLibraryFilter() async throws {
+        let provider = makeProvider()
+        let books = try await provider.fetchRecentBooks(libraryId: "5", limit: 7)
+        #expect(books.map(\.libraryId) == ["5"])
+        let request = try #require(provider.requests.last)
+        #expect(request.httpMethod == "POST")
+        #expect(request.url?.path == "/api/Series/recently-added-v2")
+        #expect(request.url?.query == "pageNumber=1&pageSize=7")
+    }
+
+    @Test func writesChapterProgressAndAllowsResetToPageZero() async throws {
+        let provider = makeProvider()
+        let book = Book(id: "3", title: "Fixture", source: .kavita, providerId: provider.connection.id, libraryId: "5")
+        try await provider.updateEbookProgress(for: book, progress: 0.42, epubLocator: nil)
+        let request = try #require(provider.requests.last)
+        let bodyData = try #require(request.httpBody)
+        let body = try #require(JSONSerialization.jsonObject(with: bodyData) as? [String: Int])
+        #expect(request.url?.path == "/api/Reader/progress")
+        #expect(body == ["seriesId": 3, "libraryId": 5, "volumeId": 7, "chapterId": 11, "pageNum": 42])
+
+        try await provider.updateEbookProgress(for: book, progress: 0, epubLocator: nil)
+        let resetData = try #require(provider.requests.last?.httpBody)
+        let reset = try #require(JSONSerialization.jsonObject(with: resetData) as? [String: Int])
+        #expect(reset["pageNum"] == 0)
+    }
+
+    @Test func readsTheSameChapterUsedForDownloadsAndUploads() async throws {
+        let provider = makeProvider()
+        let book = Book(id: "3", title: "Fixture", source: .kavita, providerId: provider.connection.id, libraryId: "5")
+        let progress = try await provider.fetchEbookProgress(for: book)
+        #expect(progress?.progress == 0.42)
+        #expect(progress?.updatedAt == ProviderProgressDate.parse("2026-08-30T18:30:00.123Z"))
+        #expect(provider.requests.last?.url?.query == "chapterId=11")
+    }
+
+    @Test func failedUploadThrowsForRetry() async throws {
+        let provider = makeProvider()
+        provider.progressStatus = 500
+        let book = Book(id: "3", title: "Fixture", source: .kavita, providerId: provider.connection.id, libraryId: "5")
+        await #expect(throws: (any Error).self) {
+            try await provider.updateEbookProgress(for: book, progress: 0.5, epubLocator: nil)
+        }
+    }
+
+    private func makeProvider() -> KavitaProgressTransportStub {
+        KavitaProgressTransportStub(connection: ServerConnection(
+            name: "Fixture", url: "https://kavita.example.invalid", type: .kavita, token: "fixture"
+        ))
+    }
+}

--- a/ios/enveTests/LinkedBookPassageTests.swift
+++ b/ios/enveTests/LinkedBookPassageTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Testing
+@testable import enve
+
+@MainActor
+struct LinkedBookPassageTests {
+    private let passage = "Beyond the silver river, Eleanor discovered a forgotten garden where crimson flowers bloomed beneath ancient willow trees."
+
+    @Test func findsUniquePassageAndPreservesPrintedPunctuation() {
+        let index = LinkedBookTextIndex(chunks: [chunk(passage)])
+        let match = LinkedBookSparseMatcher.match(
+            transcript: passage.lowercased(), expectedProgress: 0.5, in: index, requiresUniquePassage: true
+        )
+        #expect(match != nil)
+        #expect(match?.href == "chapter.xhtml")
+        #expect(passage.contains(match?.quote ?? "missing"))
+    }
+
+    @Test func refusesRepeatedPassageEvenAtExpectedPosition() {
+        let index = LinkedBookTextIndex(chunks: [
+            chunk(passage, index: 0),
+            chunk("The distant mountains were hidden by thick rolling clouds as the travelers walked slowly toward their village.", index: 1),
+            chunk(passage, index: 2),
+        ])
+        #expect(LinkedBookSparseMatcher.match(
+            transcript: passage, expectedProgress: 0.1, in: index, requiresUniquePassage: true
+        ) == nil)
+    }
+
+    @Test func refusesShortOrUnrelatedSpeech() {
+        let index = LinkedBookTextIndex(chunks: [chunk(passage)])
+        for text in ["Beyond the river", "The spacecraft entered orbit around Jupiter while mission control prepared their instruments for measuring radiation"] {
+            #expect(LinkedBookSparseMatcher.match(
+                transcript: text, expectedProgress: 0.5, in: index, requiresUniquePassage: true
+            ) == nil)
+        }
+    }
+
+    private func chunk(_ text: String, index: Int = 0) -> EbookContextChunk {
+        EbookContextChunk(id: "chunk-\(index)", bookStableId: "ebook", title: nil,
+                          href: "chapter.xhtml", index: index,
+                          startProgress: Double(index) / 3, endProgress: Double(index + 1) / 3, text: text)
+    }
+}

--- a/ios/enveTests/NowPlayingSessionLifecycleTests.swift
+++ b/ios/enveTests/NowPlayingSessionLifecycleTests.swift
@@ -1,0 +1,156 @@
+import AVFoundation
+import Foundation
+import MediaPlayer
+import Testing
+
+@testable import enve
+
+@MainActor
+struct NowPlayingSessionLifecycleTests {
+    @Test func clearingSessionLeavesItsPlayerAssociationIntact() {
+        let coordinator = NowPlayingCoordinator()
+        let target = SessionTarget()
+        let player = AVPlayer()
+        let session = MPNowPlayingSession(players: [player])
+        session.automaticallyPublishesNowPlayingInfo = false
+
+        coordinator.setNowPlayingSession(session, for: target)
+        coordinator.clearNowPlayingSession(if: target)
+        coordinator.clearNowPlayingSession(if: target)
+
+        #expect(session.players.count == 1)
+        #expect(session.players.first === player)
+    }
+
+    @Test func switchingPlayersLeavesTheRetiredSessionIntact() {
+        let coordinator = NowPlayingCoordinator()
+        let target = SessionTarget()
+        let firstPlayer = AVPlayer()
+        let secondPlayer = AVPlayer()
+        let firstSession = MPNowPlayingSession(players: [firstPlayer])
+        let secondSession = MPNowPlayingSession(players: [secondPlayer])
+        firstSession.automaticallyPublishesNowPlayingInfo = false
+        secondSession.automaticallyPublishesNowPlayingInfo = false
+
+        coordinator.setNowPlayingSession(firstSession, for: target)
+        coordinator.setNowPlayingSession(secondSession, for: target)
+
+        #expect(firstSession.players.first === firstPlayer)
+        #expect(secondSession.players.first === secondPlayer)
+        coordinator.clearNowPlayingSession(if: target)
+    }
+
+    @Test func reinstallingTheSameSessionDoesNotDetachItsPlayer() {
+        let coordinator = NowPlayingCoordinator()
+        let target = SessionTarget()
+        let player = AVPlayer()
+        let session = MPNowPlayingSession(players: [player])
+        session.automaticallyPublishesNowPlayingInfo = false
+
+        coordinator.setNowPlayingSession(session, for: target)
+        coordinator.setNowPlayingSession(session, for: target)
+
+        #expect(session.players.first === player)
+        coordinator.clearNowPlayingSession(if: target)
+    }
+
+    @Test func displacedOwnerCannotClearTheReplacementSession() async throws {
+        let coordinator = NowPlayingCoordinator()
+        let firstTarget = SessionTarget()
+        let secondTarget = SessionTarget()
+        let firstPlayer = AVPlayer()
+        let secondPlayer = AVPlayer()
+        weak var firstSession: MPNowPlayingSession?
+        weak var secondSession: MPNowPlayingSession?
+
+        autoreleasepool {
+            let session = MPNowPlayingSession(players: [firstPlayer])
+            session.automaticallyPublishesNowPlayingInfo = false
+            firstSession = session
+            coordinator.setNowPlayingSession(session, for: firstTarget)
+        }
+        autoreleasepool {
+            let session = MPNowPlayingSession(players: [secondPlayer])
+            session.automaticallyPublishesNowPlayingInfo = false
+            secondSession = session
+            coordinator.setNowPlayingSession(session, for: secondTarget)
+            coordinator.clearNowPlayingSession(if: firstTarget)
+        }
+
+        try await waitForRelease { firstSession }
+        #expect(firstSession == nil)
+        #expect(secondSession != nil)
+        autoreleasepool { coordinator.clearNowPlayingSession(if: secondTarget) }
+        try await waitForRelease { secondSession }
+        #expect(secondSession == nil)
+    }
+
+    @Test func displacedOwnerCanReclaimItsRetainedSession() async throws {
+        let coordinator = NowPlayingCoordinator()
+        let firstTarget = SessionTarget()
+        let secondTarget = SessionTarget()
+        let firstPlayer = AVPlayer()
+        let secondPlayer = AVPlayer()
+        let firstSession = MPNowPlayingSession(players: [firstPlayer])
+        firstSession.automaticallyPublishesNowPlayingInfo = false
+        weak var secondSession: MPNowPlayingSession?
+
+        coordinator.setNowPlayingSession(firstSession, for: firstTarget)
+        autoreleasepool {
+            let session = MPNowPlayingSession(players: [secondPlayer])
+            session.automaticallyPublishesNowPlayingInfo = false
+            secondSession = session
+            coordinator.setNowPlayingSession(session, for: secondTarget)
+            coordinator.setNowPlayingSession(firstSession, for: firstTarget)
+        }
+        coordinator.clearNowPlayingSession(if: secondTarget)
+        coordinator.updateNowPlaying(NowPlayingInfo(title: "Resumed episode"))
+
+        try await waitForRelease { secondSession }
+        #expect(secondSession == nil)
+        #expect(firstSession.players.first === firstPlayer)
+        #expect(firstSession.nowPlayingInfoCenter.nowPlayingInfo?[MPMediaItemPropertyTitle] as? String == "Resumed episode")
+        coordinator.clearNowPlayingSession(if: firstTarget)
+    }
+
+    @Test func repeatedPlayerReplacementReleasesEveryRetiredSession() async throws {
+        let coordinator = NowPlayingCoordinator()
+        let target = SessionTarget()
+
+        for _ in 0..<25 {
+            let player = AVPlayer()
+            weak var retiredSession: MPNowPlayingSession?
+            autoreleasepool {
+                let session = MPNowPlayingSession(players: [player])
+                session.automaticallyPublishesNowPlayingInfo = false
+                retiredSession = session
+                coordinator.setNowPlayingSession(session, for: target)
+            }
+
+            #expect(retiredSession != nil)
+            autoreleasepool { coordinator.clearNowPlayingSession(if: target) }
+            try await waitForRelease { retiredSession }
+            #expect(retiredSession == nil)
+        }
+    }
+
+    private func waitForRelease(_ session: () -> MPNowPlayingSession?) async throws {
+        // MediaPlayer can retain sessions until queued registration work completes.
+        for _ in 0..<100 {
+            if autoreleasepool(invoking: { session() == nil }) { return }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+    }
+}
+
+@MainActor
+private final class SessionTarget: RemoteCommandTarget {
+    func remotePlay() {}
+    func remotePause() {}
+    func remoteToggle() {}
+    func remoteNext() {}
+    func remotePrevious() {}
+    func remoteSkipForward(by seconds: TimeInterval?) {}
+    func remoteSkipBackward(by seconds: TimeInterval?) {}
+    func remoteSeek(to positionTime: TimeInterval) {}
+}

--- a/ios/enveTests/PendingSyncQueueFlusherTests.swift
+++ b/ios/enveTests/PendingSyncQueueFlusherTests.swift
@@ -114,6 +114,56 @@ struct PendingSyncQueueFlusherTests {
         #expect(fixture.store.isEmpty)
     }
 
+    @Test(arguments: [200, 401, 404, 503])
+    func inFlightResultDoesNotMutateReplacement(status: Int) async {
+        let fixture = makeStore()
+        defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }
+        fixture.store.enqueue(entry(id: "book", updatedAt: 10))
+        let replacement = entry(id: "book", updatedAt: 20)
+        let transport = PendingSyncTransportStub()
+        transport.waitsForRelease = true
+        if status != 200 {
+            transport.results["book"] = [.failure(ProviderError.serverError("HTTP \(status)"))]
+        }
+        let flusher = PendingSyncQueueFlusher(store: fixture.store, transport: transport)
+
+        let task = Task { @MainActor in await flusher.flush() }
+        while transport.attempts.isEmpty { await Task.yield() }
+        fixture.store.enqueue(replacement)
+        transport.release()
+        await task.value
+
+        #expect(fixture.store.entries["book"] == replacement)
+        transport.waitsForRelease = false
+        await flusher.flush()
+        #expect(transport.attempts == ["book", "book"])
+        #expect(fixture.store.isEmpty)
+    }
+
+    @Test func flushSkipsEntriesReplacedWhileAnotherRequestIsInFlight() async {
+        let fixture = makeStore()
+        defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }
+        fixture.store.enqueue(entry(id: "first", updatedAt: 10))
+        fixture.store.enqueue(entry(id: "second", updatedAt: 20))
+        let replacement = entry(id: "second", updatedAt: 30)
+        let transport = PendingSyncTransportStub()
+        transport.waitsForRelease = true
+        let flusher = PendingSyncQueueFlusher(store: fixture.store, transport: transport)
+
+        let task = Task { @MainActor in await flusher.flush() }
+        while transport.attempts.isEmpty { await Task.yield() }
+        fixture.store.enqueue(replacement)
+        transport.waitsForRelease = false
+        transport.release()
+        await task.value
+
+        #expect(transport.attempts == ["first"])
+        #expect(fixture.store.entries["second"] == replacement)
+        await flusher.flush()
+        #expect(transport.attempts == ["first", "second"])
+        #expect(fixture.store.isEmpty)
+    }
+
     @Test func retryUsesInjectedClockAndDoesNotPushDuringBackoff() async {
         let fixture = makeStore()
         defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }

--- a/ios/enveTests/PlaybackResumeRegressionTests.swift
+++ b/ios/enveTests/PlaybackResumeRegressionTests.swift
@@ -4,6 +4,53 @@ import Testing
 @testable import enve
 
 struct PlaybackResumeRegressionTests {
+    @Test func playerBookmarksAlwaysResolveAudiobookPositions() {
+        let book = Book(id: "book", title: "Book", mediaType: .audiobook)
+        let bookmark = Bookmark(
+            bookId: book.stableId,
+            position: 321,
+            title: "Scene",
+            mediaType: .audiobook
+        )
+
+        #expect(PlayerBookmarkNavigation.audioSeekPosition(for: bookmark, playbackBook: book) == 321)
+    }
+
+    @Test func legacyReadAloudPlayerBookmarksStillResolveAudioPositions() {
+        let book = Book(
+            id: "read-aloud",
+            title: "Read Aloud",
+            mediaType: .ebook,
+            epub3Features: EPUB3Features(hasMediaOverlay: true)
+        )
+        let bookmark = Bookmark(
+            bookId: book.stableId,
+            position: 654,
+            title: "Legacy audio bookmark",
+            mediaType: .ebook
+        )
+
+        #expect(PlayerBookmarkNavigation.audioSeekPosition(for: bookmark, playbackBook: book) == 654)
+    }
+
+    @Test func ebookLocatorBookmarksRemainReaderNavigationTargets() {
+        let book = Book(
+            id: "read-aloud",
+            title: "Read Aloud",
+            mediaType: .ebook,
+            epub3Features: EPUB3Features(hasMediaOverlay: true)
+        )
+        let bookmark = Bookmark(
+            bookId: book.stableId,
+            position: 0.4,
+            title: "Page bookmark",
+            locator: #"{"href":"chapter.xhtml","locations":{"progression":0.4}}"#,
+            mediaType: .ebook
+        )
+
+        #expect(PlayerBookmarkNavigation.audioSeekPosition(for: bookmark, playbackBook: book) == nil)
+    }
+
     @Test func nowPlayingKeepsBookGlobalProgressWhileShowingChapterMetadata() {
         let book = Book(
             id: "book",

--- a/ios/enveTests/PlexAlbumGroupingTests.swift
+++ b/ios/enveTests/PlexAlbumGroupingTests.swift
@@ -1,0 +1,112 @@
+import Foundation
+import Testing
+@testable import enve
+
+@MainActor
+struct PlexAlbumGroupingTests {
+    private let provider = PlexProvider(connection: ServerConnection(
+        name: "Plex", url: "https://example.invalid", type: .plex))
+
+    private func metadata(_ id: String, title: String, path: String? = nil) throws -> PlexProvider.PlexMetadata {
+        var fields: [String: Any] = ["ratingKey": id, "key": "/library/metadata/\(id)",
+            "title": title, "type": path == nil ? "album" : "track", "duration": 45000,
+            "parentTitle": "[Unknown Album]", "grandparentTitle": "Test Author"]
+        if let path {
+            fields["Media"] = [["Part": [["key": "/library/parts/\(id)/file", "file": path]]]]
+        }
+        return try JSONDecoder().decode(PlexProvider.PlexMetadata.self, from: JSONSerialization.data(withJSONObject: fields))
+    }
+
+    @Test func unrelatedLooseBooksKeepTheirOwnIdentityAndTimeline() throws {
+        let album = try metadata("1", title: "[Unknown Album]")
+        let tracks = try [metadata("2", title: "First", path: "/books/First.m4b"),
+            metadata("3", title: "Second", path: "/books/Second.mp3"),
+            metadata("4", title: "Third", path: "/books/Third.m4b")]
+        let books = provider.mapPlexAlbum(album, tracks: tracks, libraryId: "library", libraryRoots: ["/books"])
+        #expect(books.map(\.id) == ["2", "3", "4"])
+        #expect(books.map(\.title) == ["First", "Second", "Third"])
+        #expect(books.allSatisfy { $0.duration == 45 && $0.audioTracks?.count == 1 })
+        #expect(books.allSatisfy { $0.seriesInfo?.name != "[Unknown Album]" })
+        #expect(resolvePlexProgressTarget(book: books[1], currentTime: 12).ratingKey == "3")
+    }
+
+    @Test func numberedChaptersKeepAlbumIdentityAndUseFolderTitle() throws {
+        let album = try metadata("1", title: "Unknown Album (02/01/2018 7:34:00 PM)")
+        let tracks = try [metadata("2", title: "Story", path: "/books/Story/001 Story.mp3"),
+            metadata("3", title: "Story", path: "/books/Story/002 Story.mp3")]
+        let books = provider.mapPlexAlbum(album, tracks: tracks, libraryId: "library", libraryRoots: ["/books"])
+        #expect(books.count == 1)
+        #expect(books.first?.id == "1")
+        #expect(books.first?.title == "Story")
+        #expect(books.first?.duration == 90)
+        #expect(books.first?.audioTracks?.map(\.startOffset) == [0, 45])
+    }
+
+    @Test func genericPartNamesStayTogether() throws {
+        let tracks = try [metadata("2", title: "Part 001", path: "/books/Story/Part 001.mp3"),
+            metadata("3", title: "Part 002", path: "/books/Story/Part 002.mp3")]
+        let books = provider.mapPlexAlbum(try metadata("1", title: "[Unknown Album]"), tracks: tracks, libraryId: "library", libraryRoots: ["/books"])
+        #expect(books.count == 1)
+        #expect(books.first?.title == "Story")
+    }
+
+    @Test func namedAlbumPreservesItsMetadata() throws {
+        let tracks = try [metadata("2", title: "First", path: "/books/First.mp3"),
+            metadata("3", title: "Second", path: "/books/Second.mp3")]
+        let books = provider.mapPlexAlbum(try metadata("1", title: "Named Album"), tracks: tracks, libraryId: "library", libraryRoots: ["/books"])
+        #expect(books.count == 1)
+        #expect(books.first?.title == "Named Album")
+        #expect(books.first?.id == "1")
+    }
+    @Test func unnumberedChaptersStayInTheirBookFolder() throws {
+        let tracks = try [metadata("2", title: "Prologue", path: "/books/Story/Prologue.mp3"),
+            metadata("3", title: "The Journey", path: "/books/Story/The Journey.mp3"),
+            metadata("4", title: "Epilogue", path: "/books/Story/Epilogue.mp3")]
+        let books = provider.mapPlexAlbum(try metadata("1", title: "[Unknown Album]"), tracks: tracks,
+            libraryId: "library", libraryRoots: ["/books"])
+        #expect(books.count == 1)
+        #expect(books.first?.title == "Story")
+        #expect(books.first?.id == "1")
+    }
+
+    @Test func discFoldersKeepOneBookInNaturalOrder() throws {
+        let tracks = try [metadata("20", title: "Second", path: "/books/Story/CD2/01.mp3"),
+            metadata("30", title: "First", path: "/books/Story/CD1/02.mp3"),
+            metadata("10", title: "Opening", path: "/books/Story/CD1/01.mp3")]
+        let books = provider.mapPlexAlbum(try metadata("1", title: "[Unknown Album]"), tracks: tracks,
+            libraryId: "library", libraryRoots: ["/books"])
+        #expect(books.count == 1)
+        #expect(books.first?.title == "Story")
+        #expect(books.first?.audioTracks?.map(\.id) == ["10", "30", "20"])
+    }
+
+    @Test func numberedRootBooksAreNotMistakenForChapters() throws {
+        let tracks = try [metadata("2", title: "1984", path: "/books/1984.m4b"),
+            metadata("3", title: "First", path: "/books/01 First Book.m4b"),
+            metadata("4", title: "Second", path: "/books/02 Second Book.m4b")]
+        let books = provider.mapPlexAlbum(try metadata("1", title: "[Unknown Album]"), tracks: tracks,
+            libraryId: "library", libraryRoots: ["/books"])
+        #expect(books.map(\.title) == ["1984", "01 First Book", "02 Second Book"])
+    }
+
+    @Test func missingPathsOrLibraryRootsKeepAlbumIdentity() throws {
+        let album = try metadata("1", title: "[Unknown Album]")
+        let tracks = try [metadata("2", title: "Chapter"), metadata("3", title: "Another")]
+        #expect(provider.mapPlexAlbum(album, tracks: tracks, libraryId: "library", libraryRoots: ["/books"]).first?.id == "1")
+        let located = try [metadata("2", title: "First", path: "/books/First.m4b"), metadata("3", title: "Second", path: "/books/Second.m4b")]
+        #expect(provider.mapPlexAlbum(album, tracks: located, libraryId: "library").count == 1)
+    }
+
+    @Test func existingUserDataPreventsDestructiveRegrouping() {
+        var book = Book(id: "album", title: "Unknown Album", mediaType: .audiobook)
+        #expect(!PlexProvider.shouldPreserveAlbum(book, hasBookmarks: false, isDownloaded: false))
+        #expect(PlexProvider.shouldPreserveAlbum(book, hasBookmarks: true, isDownloaded: false))
+        #expect(PlexProvider.shouldPreserveAlbum(book, hasBookmarks: false, isDownloaded: true))
+        book.currentTime = 60
+        #expect(PlexProvider.shouldPreserveAlbum(book, hasBookmarks: false, isDownloaded: false))
+        book.currentTime = 0
+        book.isFinished = true
+        #expect(PlexProvider.shouldPreserveAlbum(book, hasBookmarks: false, isDownloaded: false))
+    }
+
+}

--- a/ios/enveTests/PlexPlaybackSessionTests.swift
+++ b/ios/enveTests/PlexPlaybackSessionTests.swift
@@ -1,0 +1,105 @@
+import Foundation
+import Testing
+
+@testable import enve
+
+private final class PlexPlaybackTransportStub: PlexProvider, @unchecked Sendable {
+    var requests: [URLRequest] = []
+    var status = 200
+    var missingPart = false
+
+    override func performDataTask(for request: URLRequest, retryCount: Int = 3) async throws -> (Data, URLResponse) {
+        requests.append(request)
+        let url = try #require(request.url)
+        let metadata: [[String: Any]] = ["10", "30"].map { id in
+            var item: [String: Any] = [
+                "ratingKey": id,
+                "key": "/library/metadata/\(id)",
+                "parentRatingKey": id == "10" ? "album-a" : "album-b",
+                "title": "Server title \(id)",
+                "type": "track",
+                "duration": 999000,
+            ]
+            if !missingPart || id != "30" {
+                item["Media"] = [["Part": [["key": "/library/parts/\(id)/fresh.mp3"]]]]
+            }
+            return item
+        }
+        let data = try JSONSerialization.data(withJSONObject: ["MediaContainer": ["Metadata": metadata]])
+        return (data, try #require(HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil)))
+    }
+}
+
+@MainActor
+struct PlexPlaybackSessionTests {
+    @Test func repeatedPlaybackRefreshesCorruptedURLsWithoutChangingGroupedTimeline() async throws {
+        let provider = makeProvider()
+        let book = makeBook()
+        let first = try await provider.startPlaybackSession(for: book)
+
+        #expect(first.audioTracks.map(\.id) == ["30", "10"])
+        #expect(first.audioTracks.map(\.index) == [0, 1])
+        #expect(first.audioTracks.map(\.startOffset) == [0, 45])
+        #expect(first.audioTracks.map(\.duration) == [45, 60])
+        #expect(first.audioTracks.map(\.title) == ["Opening", "Closing"])
+        #expect(first.audioTracks.map(\.mimeType) == ["audio/mpeg", "audio/mp4"])
+        #expect(provider.requests.count == 1)
+        #expect(provider.requests.first?.url?.path == "/library/metadata/30,10")
+
+        for (track, id) in zip(first.audioTracks, ["30", "10"]) {
+            let components = try #require(URLComponents(string: track.contentUrl))
+            #expect(components.scheme == "https")
+            #expect(components.host == "plex.example.invalid")
+            #expect(components.path == "/library/parts/\(id)/fresh.mp3")
+            #expect(components.queryItems?.filter { $0.name == "X-Plex-Token" }.map(\.value) == ["current-fixture-token"])
+            #expect(components.queryItems?.first { $0.name == "download" }?.value == "1")
+        }
+
+        let savedTracks = try first.audioTracks.map { track in
+            AudioTrack(
+                id: try #require(track.id), index: track.index, title: track.title,
+                contentUrl: track.contentUrl, duration: track.duration,
+                startOffset: track.startOffset, format: track.mimeType
+            )
+        }
+        let savedBook = Book(id: book.id, title: book.title, source: .plex, audioTracks: savedTracks)
+        let second = try await provider.startPlaybackSession(for: savedBook)
+        #expect(second.audioTracks.map(\.contentUrl) == first.audioTracks.map(\.contentUrl))
+        #expect(second.audioTracks.map(\.startOffset) == first.audioTracks.map(\.startOffset))
+        #expect(provider.requests.count == 2)
+        #expect(provider.requests.allSatisfy { $0.url?.path == "/library/metadata/30,10" })
+    }
+
+    @Test func missingPartFailsInsteadOfReturningAnIncompleteTimeline() async {
+        let provider = makeProvider()
+        provider.missingPart = true
+        await #expect(throws: (any Error).self) {
+            try await provider.startPlaybackSession(for: makeBook())
+        }
+    }
+
+    @Test func unsuccessfulMetadataResponseFailsEvenWithDecodableBody() async {
+        let provider = makeProvider()
+        provider.status = 503
+        await #expect(throws: (any Error).self) {
+            try await provider.startPlaybackSession(for: makeBook())
+        }
+    }
+
+    private func makeProvider() -> PlexPlaybackTransportStub {
+        PlexPlaybackTransportStub(connection: ServerConnection(
+            name: "Fixture", url: "https://plex.example.invalid", type: .plex, token: "current-fixture-token"
+        ))
+    }
+
+    private func makeBook() -> Book {
+        Book(id: "grouped-albums", title: "Fixture", source: .plex, audioTracks: [
+            AudioTrack(id: "30", index: 0, title: "Opening",
+                contentUrl: "https://old.example.invalid/https://old.example.invalid/library/parts/stale/file?X-Plex-Token=stale-fixture",
+                duration: 45, startOffset: 0, format: "audio/mpeg"),
+            AudioTrack(id: "10", index: 1, title: "Closing",
+                contentUrl: "https://old.example.invalid/https://old.example.invalid/https://old.example.invalid/library/parts/stale/file",
+                duration: 60, startOffset: 45, format: "audio/mp4"),
+        ])
+    }
+}

--- a/ios/enveTests/ProviderEbookAPIContractTests.swift
+++ b/ios/enveTests/ProviderEbookAPIContractTests.swift
@@ -14,9 +14,25 @@ struct ProviderEbookAPIContractTests {
         let komga: any ProviderConnectionHandling = KomgaProvider(connection: connection(type: .komga))
         #expect(komga is any EbookDownloadProvider)
         #expect(komga is any EbookProgressPushing)
-        #expect(!(komga is any EbookProgressPulling))
+        #expect(komga is any EbookProgressPulling)
         #expect(komga is any ServerPageProvider)
         #expect(!(komga is any PlaybackSessionProvider))
+
+        let abs: any ProviderConnectionHandling = AudiobookshelfProvider(connection: connection(type: .audiobookshelf))
+        #expect(abs is any EbookProgressProvider)
+        #expect(abs.capabilities.contains(.ebookProgressPush))
+        let plex: any ProviderConnectionHandling = PlexProvider(connection: connection(type: .plex))
+        #expect(plex is any AudiobookProgressProvider)
+        #expect(plex.capabilities.contains(.audiobookProgressPull))
+        let kavita: any ProviderConnectionHandling = KavitaProvider(connection: connection(type: .kavita))
+        #expect(kavita is any EbookProgressProvider)
+        #expect(kavita.capabilities.contains(.ebookProgressPull))
+
+        let jellyfin: any ProviderConnectionHandling = JellyfinProvider(connection: connection(type: .jellyfin))
+        #expect(jellyfin is any AudiobookProgressProvider)
+        #expect(jellyfin is any EbookDownloadProvider)
+        #expect(!(jellyfin is any EbookProgressProvider))
+        #expect(!jellyfin.capabilities.contains(.ebookProgressPush))
 
         let webDAV: any ProviderConnectionHandling = WebDAVProvider(connection: connection(type: .webdav))
         #expect(webDAV is any PlaybackSessionProvider)
@@ -44,6 +60,21 @@ struct ProviderEbookAPIContractTests {
         )
 
         #expect(mediaType == .ebook)
+    }
+
+    @Test @MainActor func opdsPreservesTrailingSlashInFeedURL() {
+        let connection = ServerConnection(
+            name: "Project Gutenberg",
+            url: "https://www.gutenberg.org/ebooks/search.opds/?sort_order=downloads",
+            type: .opds
+        )
+
+        let provider = OPDSProvider(connection: connection)
+
+        #expect(
+            provider.feedURL().absoluteString
+                == "https://www.gutenberg.org/ebooks/search.opds/?sort_order=downloads"
+        )
     }
 
     @Test func audiobookshelfKeepsDualFormatItemsAudiobookFirst() {

--- a/ios/enveTests/ProviderLiveSyncTests.swift
+++ b/ios/enveTests/ProviderLiveSyncTests.swift
@@ -1,0 +1,229 @@
+import Foundation
+import Testing
+
+@testable import enve
+
+@MainActor
+struct ProviderLiveSyncTests {
+    @Test(.enabled(if: ProcessInfo.processInfo.environment["ENVE_LAB_DOCUMENT"] != nil),
+          arguments: ["Audiobookshelf", "Jellyfin", "Emby", "Plex", "Komga", "Kavita", "Grimmory", "Storyteller", "BookOrbit", "Silo"].filter {
+              guard let selected = ProcessInfo.processInfo.environment["ENVE_LAB_SERVICE"] else { return true }
+              return $0 == selected
+          })
+    func progressRoundTrip(service: String) async throws {
+        let document = try #require(ProcessInfo.processInfo.environment["ENVE_LAB_DOCUMENT"])
+        let text = try String(contentsOfFile: document, encoding: .utf8)
+        var rows: [String: String] = [:]
+        var endpoints: [String: String] = [:]
+        func values(_ row: String) -> [String] {
+            row.split(separator: "`", omittingEmptySubsequences: false).enumerated()
+                .filter { $0.offset % 2 == 1 }.map { String($0.element) }
+        }
+        for line in text.split(separator: "\n") {
+            let cells = line.split(separator: "|", omittingEmptySubsequences: false)
+                .map { $0.trimmingCharacters(in: .whitespaces) }
+            guard cells.count >= 4 else { continue }
+            rows[cells[1]] = cells[2]
+            if let url = values(cells[2]).first, url.hasPrefix("http") { endpoints[cells[1]] = url }
+        }
+        let endpoint = try #require(endpoints[service])
+        let host = try #require(URL(string: endpoint)?.host)
+        let permittedHosts = ["LAN address", "Tailscale address"].flatMap { values(rows[$0] ?? "") }
+        guard permittedHosts.contains(host) else { throw LabError.nonLabEndpoint }
+        var username = try #require(values(rows["Username"] ?? "").first)
+        var password = try #require(values(rows["Password"] ?? "").first)
+        if service == "Komga" { username = try #require(values(rows["Email"] ?? "").first) }
+        if service == "Storyteller" { username = try #require(values(rows["Storyteller local administrator"] ?? "").first) }
+        if service == "BookOrbit" {
+            let credentials = values(rows[service] ?? "")
+            username = try #require(credentials.first)
+            password = try #require(credentials.last)
+        }
+        let type: ProviderType
+        switch service {
+        case "Audiobookshelf": type = .audiobookshelf
+        case "Jellyfin": type = .jellyfin
+        case "Emby": type = .emby
+        case "Plex": type = .plex
+        case "Komga": type = .komga
+        case "Kavita": type = .kavita
+        case "Grimmory": type = .booklore
+        case "Storyteller": type = .storyteller
+        case "BookOrbit": type = .bookOrbit
+        default: type = .silo
+        }
+        let plexToken = service == "Plex" ? values(rows["Plex token"] ?? "").first : nil
+        let connection = ServerConnection(name: "Disposable sync test", url: endpoint, type: type,
+                                          username: username, password: password, token: plexToken)
+        let provider: any LibraryProvider
+        switch type {
+        case .audiobookshelf: provider = AudiobookshelfProvider(connection: connection)
+        case .jellyfin: provider = JellyfinProvider(connection: connection)
+        case .emby: provider = EmbyProvider(connection: connection)
+        case .plex: provider = PlexProvider(connection: connection)
+        case .komga: provider = KomgaProvider(connection: connection)
+        case .kavita: provider = KavitaProvider(connection: connection)
+        case .booklore: provider = BookloreProvider(connection: connection)
+        case .storyteller: provider = StorytellerProvider(connection: connection)
+        case .bookOrbit: provider = BookOrbitProvider(connection: connection)
+        default: provider = SiloProvider(connection: connection)
+        }
+        var stage = "authentication"
+        do {
+            guard try await provider.validateConnection() else { throw LabError.rejected }
+            record("LAB \(service) authentication passed")
+            stage = "catalog"
+            let libraries = try await provider.fetchLibraries()
+            var books: [Book] = []
+            for library in libraries {
+                if service == "Plex", !library.name.localizedCaseInsensitiveContains("audiobook") { continue }
+                if service == "Emby" || service == "Jellyfin" || service == "BookOrbit" {
+                    books += try await provider.fetchBooks(libraryId: library.id)
+                } else {
+                    books += try await provider.fetchRecentBooks(libraryId: library.id, limit: 10)
+                }
+            }
+            record("LAB \(service) catalog libraries=\(libraries.count) books=\(books.count) ebooks=\(books.filter { $0.mediaType == .ebook }.count)")
+            guard !books.isEmpty else { throw LabError.emptyCatalog }
+            if service == "BookOrbit" {
+                for book in books {
+                    let detail = try await provider.fetchFullBookDetails(bookId: book.id, libraryId: book.libraryId)
+                    guard detail.id == book.id else { throw LabError.rejected }
+                }
+                record("LAB BookOrbit full catalog and details passed books=\(books.count)")
+            }
+            if let candidate = books.first(where: { $0.mediaType == .audiobook && ($0.duration ?? 0) <= 0 }),
+               let index = books.firstIndex(where: { $0.stableId == candidate.stableId }) {
+                books[index] = try await provider.fetchFullBookDetails(bookId: candidate.id, libraryId: candidate.libraryId)
+            }
+            if let download = provider as? any EbookDownloadProvider,
+               let book = books.first(where: { $0.mediaType == .ebook && $0.ebookFormat?.lowercased() == "epub" }) ?? books.first(where: { $0.mediaType == .ebook }) {
+                stage = "ebook download"
+                let url = try await download.downloadEbook(for: book, onProgress: nil)
+                let size = try url.resourceValues(forKeys: [.fileSizeKey]).fileSize ?? 0
+                guard size > 0 else { throw LabError.rejected }
+                record("LAB \(service) ebook downloaded bytes=\(size)")
+            }
+            if let sync = provider as? any EbookProgressProvider,
+               let book = books.first(where: { $0.mediaType == .ebook && $0.ebookFormat?.lowercased() == "epub" }) ?? books.first(where: { $0.mediaType == .ebook }) {
+                stage = "ebook round trip"
+                record("LAB \(service) ebook fixture=\(book.title)")
+                let tolerance: Double
+                if let pages = provider as? KomgaProvider {
+                    tolerance = 1 / Double(try await pages.fetchPageCount(for: book)) + 0.001
+                } else if let kavita = provider as? KavitaProvider {
+                    let request = try kavita.makeRequest(path: "/api/Series/volumes?seriesId=\(book.id)")
+                    let (data, _) = try await kavita.send(request)
+                    let volumes = try #require(JSONSerialization.jsonObject(with: data) as? [[String: Any]])
+                    let chapters = try #require(volumes.first?["chapters"] as? [[String: Any]])
+                    let pages = try #require(chapters.first?["pages"] as? Int)
+                    tolerance = 1 / Double(pages) + 0.001
+                } else { tolerance = 0.06 }
+                let original = try await sync.fetchEbookProgress(for: book)
+                do {
+                    for fraction in [0.42, 1.0, 0.0] {
+                        try await sync.updateEbookProgress(for: book, progress: fraction, epubLocator: nil)
+                        let remote = try await sync.fetchEbookProgress(for: book)
+                        record("LAB \(service) ebook sent=\(fraction) received=\(remote?.progress ?? -1)")
+                        guard abs((remote?.progress ?? 0) - fraction) < tolerance else { throw LabError.progressMismatch }
+                    }
+                } catch {
+                    try await sync.updateEbookProgress(for: book, progress: original?.progress ?? 0, epubLocator: original?.locator)
+                    throw error
+                }
+                try await sync.updateEbookProgress(for: book, progress: original?.progress ?? 0, epubLocator: original?.locator)
+            }
+            if let sync = provider as? any AudiobookProgressProvider,
+               let book = books.first(where: { $0.mediaType == .audiobook && ($0.duration ?? 0) > 30 }) {
+                stage = "audiobook round trip"
+                record("LAB \(service) audio fixture=\(book.title) duration=\(book.duration ?? 0) podcast=\(book.isPodcastEpisode)")
+                let original = try await sync.fetchAudiobookProgress(for: book)
+                var activeSession: PlaybackSessionInfo?
+                do {
+                    if let playback = provider as? any PlaybackSessionProvider {
+                        stage = "stream and seek"
+                        let session = try await playback.startPlaybackSession(for: book)
+                        activeSession = session
+                        let track = try #require(session.audioTracks.first)
+                        let url = try #require(URL(string: track.contentUrl))
+                        for offset in [0, 65536] {
+                            var request = URLRequest(url: url)
+                            request.timeoutInterval = 30
+                            for (key, value) in playback.getStreamingHeaders() { request.setValue(value, forHTTPHeaderField: key) }
+                            request.setValue("bytes=\(offset)-\(offset + 1023)", forHTTPHeaderField: "Range")
+                            let (data, response) = try await URLSession.shared.data(for: request)
+                            let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+                            record("LAB \(service) stream range=\(offset) HTTP=\(status)")
+                            guard status == 206, !data.isEmpty else { throw LabError.rejected }
+                        }
+                        record("LAB \(service) stream and byte-range seek passed")
+                    }
+                    stage = "audiobook round trip"
+                    for seconds in [23.0, 0.0] {
+                        try await sync.updatePlaybackProgress(book: book, sessionId: nil, currentTime: seconds, isFinished: false, timeListened: 0)
+                        let remote = try await sync.fetchAudiobookProgress(for: book)
+                        record("LAB \(service) audiobook sent=\(seconds) received=\(remote?.positionSeconds ?? -1)")
+                        guard abs((remote?.positionSeconds ?? 0) - seconds) < 1 else { throw LabError.progressMismatch }
+                    }
+                } catch {
+                    try await sync.updatePlaybackProgress(book: book, sessionId: nil, currentTime: original?.positionSeconds ?? 0, isFinished: book.isFinished, timeListened: 0)
+                    try await closeSession(activeSession, provider: provider, book: book, position: original?.positionSeconds ?? 0)
+                    throw error
+                }
+                try await sync.updatePlaybackProgress(book: book, sessionId: nil, currentTime: original?.positionSeconds ?? 0, isFinished: book.isFinished, timeListened: 0)
+                try await closeSession(activeSession, provider: provider, book: book, position: original?.positionSeconds ?? 0)
+            }
+            record("LAB \(service) passed")
+        } catch {
+            let message: String
+            if let decoding = error as? DecodingError {
+                switch decoding {
+                case .keyNotFound(let key, _): message = "missing key " + key.stringValue
+                case .typeMismatch(_, let context), .valueNotFound(_, let context), .dataCorrupted(let context):
+                    message = "decode " + context.codingPath.map(\.stringValue).joined(separator: ".")
+                @unknown default: message = "decode failure"
+                }
+            } else {
+                message = String(reflecting: Swift.type(of: error)) + " code " + String((error as NSError).code)
+            }
+            record("LAB \(service) failed at \(stage): \(message)")
+            Issue.record("Lab \(service) failed at \(stage): \(message)")
+        }
+    }
+
+    private func closeSession(_ session: PlaybackSessionInfo?, provider: any LibraryProvider, book: Book, position: Double) async throws {
+        guard let session, let playback = provider as? any PlaybackSessionProvider else { return }
+        let path: String
+        switch provider.connection.type {
+        case .audiobookshelf: path = "/api/session/\(session.sessionId)/close"
+        case .silo: path = "/api/v1/playback/\(session.sessionId)"
+        default: return
+        }
+        let url = try #require(URL(string: provider.connection.url + path))
+        var request = URLRequest(url: url)
+        request.httpMethod = provider.connection.type == .silo ? "DELETE" : "POST"
+        for (key, value) in playback.getStreamingHeaders() { request.setValue(value, forHTTPHeaderField: key) }
+        if provider.connection.type == .audiobookshelf {
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.httpBody = try JSONSerialization.data(withJSONObject: [
+                "currentTime": position, "duration": book.duration ?? 0, "timeListened": 0,
+            ])
+        }
+        let (_, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else { throw LabError.rejected }
+    }
+
+    private func record(_ message: String) {
+        print(message)
+        if let path = ProcessInfo.processInfo.environment["ENVE_LAB_EVENTS"],
+           let handle = FileHandle(forWritingAtPath: path) {
+            defer { try? handle.close() }
+            handle.seekToEndOfFile()
+            handle.write(Data((message + "\n").utf8))
+        }
+    }
+
+    private enum LabError: Error {
+        case nonLabEndpoint, rejected, emptyCatalog, progressMismatch
+    }
+}

--- a/ios/enveTests/ProviderSyncSinkTests.swift
+++ b/ios/enveTests/ProviderSyncSinkTests.swift
@@ -19,7 +19,7 @@ private final class ProviderResolverStub: LibraryProviderResolving {
 }
 
 @MainActor
-private final class ProgressProviderStub: @MainActor LibraryProvider, @MainActor AudiobookProgressProvider {
+final class ProgressProviderStub: @MainActor LibraryProvider, @MainActor AudiobookProgressProvider {
     struct PlaybackUpdate: Equatable {
         let bookId: String
         let sessionId: String?
@@ -30,6 +30,7 @@ private final class ProgressProviderStub: @MainActor LibraryProvider, @MainActor
 
     var connection: ServerConnection
     var audiobookProgress: ProviderAudiobookProgress?
+    var pullError: Error?
     private(set) var playbackUpdates: [PlaybackUpdate] = []
 
     init(connection: ServerConnection) {
@@ -69,7 +70,8 @@ private final class ProgressProviderStub: @MainActor LibraryProvider, @MainActor
         )
     }
     func fetchAudiobookProgressState(for book: Book) async throws -> ProviderAudiobookProgress? {
-        audiobookProgress
+        if let pullError { throw pullError }
+        return audiobookProgress
     }
 
     func fetchAudiobookProgress(
@@ -165,7 +167,7 @@ struct ProviderSyncSinkTests {
         #expect(store.allBackends().contains(where: { $0.id == connectionId.uuidString }))
     }
 
-    @Test func resolvesByBookAndMapsAudiobookProgress() async {
+    @Test func resolvesByBookAndMapsAudiobookProgress() async throws {
         let providerId = UUID()
         let connection = ServerConnection(
             id: providerId,
@@ -187,13 +189,26 @@ struct ProviderSyncSinkTests {
         let book = makeBook(providerId: providerId)
         let sink = ProviderSyncSink(providerResolver: resolver)
 
-        let snapshot = await sink.pull(book: book, domain: .audiobook)
+        let snapshot = try await sink.pull(book: book, domain: .audiobook)
 
         #expect(resolver.requestedBooks.map(\.id) == [book.id])
         #expect(snapshot?.positionSeconds == 25)
         #expect(snapshot?.progress == 0.25)
         #expect(snapshot?.lastUpdate == Date(timeIntervalSince1970: 500))
         #expect(snapshot?.source == "Test Server")
+    }
+
+    @Test func providerPullFailureIsNotAnEmptySuccess() async throws {
+        let connection = ServerConnection(name: "Fixture", url: "https://example.invalid", type: .jellyfin)
+        let provider = ProgressProviderStub(connection: connection)
+        provider.pullError = URLError(.timedOut)
+        let resolver = ProviderResolverStub()
+        resolver.providers[connection.id] = provider
+        let sink = ProviderSyncSink(providerResolver: resolver)
+        let book = makeBook(providerId: connection.id)
+        await #expect(throws: URLError.self) {
+            _ = try await sink.pull(book: book, domain: .audiobook)
+        }
     }
 
     @Test func routesAudiobookPushThroughResolvedCapability() async throws {

--- a/ios/enveTests/RecentlyPlayedSyncServiceTests.swift
+++ b/ios/enveTests/RecentlyPlayedSyncServiceTests.swift
@@ -9,11 +9,12 @@ import Testing
 private final class ProviderConnectionStub: ProviderConnectionAccessing {
     var connections: [ServerConnection] = []
     var backends: [BackendConfig] = []
+    var providers: [UUID: LibraryProvider] = [:]
 
     func backend(id: String) -> BackendConfig? { backends.first { $0.id == id } }
     func allBackends() -> [BackendConfig] { backends }
-    func provider(for providerId: UUID) -> LibraryProvider? { nil }
-    func provider(for book: Book) -> LibraryProvider? { nil }
+    func provider(for providerId: UUID) -> LibraryProvider? { providers[providerId] }
+    func provider(for book: Book) -> LibraryProvider? { providers[book.providerId] }
 }
 
 @MainActor
@@ -225,7 +226,8 @@ private func makeBook(
     duration: TimeInterval? = 600,
     ebookProgress: Double? = nil,
     lastUpdate: Date = Date(timeIntervalSince1970: 1_000),
-    readAloudSourceStableId: String? = nil
+    readAloudSourceStableId: String? = nil,
+    backendId: String = "abs"
 ) -> Book {
     Book(
         id: id,
@@ -236,7 +238,7 @@ private func makeBook(
         lastUpdate: lastUpdate,
         libraryId: "library",
         providerId: testProviderId,
-        backendId: "backend",
+        backendId: backendId,
         source: .audiobookshelf,
         readAloudSourceStableId: readAloudSourceStableId
     )
@@ -319,7 +321,7 @@ struct RecentlyPlayedSyncServiceTests {
         let fixture = try WorkerFixture()
         fixture.connections.backends = [
             makeBackend(id: "abs"),
-            makeBackend(id: "emby", type: .emby),
+            makeBackend(id: "second-abs"),
             makeBackend(id: "jellyfin-off", type: .jellyfin, enabled: false),
             makeBackend(id: "plex", type: .plex),
         ]
@@ -334,8 +336,8 @@ struct RecentlyPlayedSyncServiceTests {
 
         let result = await fixture.makeService().sync(trigger: .appLaunch)
 
-        #expect(result.attemptedBackendCount == 5)
-        #expect(fixture.progressAPI.queriedBackends == ["abs", "emby"])
+        #expect(result.attemptedBackendCount == 6)
+        #expect(fixture.progressAPI.queriedBackends == ["abs", "second-abs"])
     }
 
     @Test func skipsAbsorbedAndCurrentlyPlayingBooks() async throws {
@@ -411,7 +413,7 @@ struct RecentlyPlayedSyncServiceTests {
         #expect(fixture.libraryCache.mutatedStableIds.isEmpty)
     }
 
-    @Test func failedEbookPushDoesNotMarkTheBackendFailed() async throws {
+    @Test func failedEbookPushMarksTheBackendFailed() async throws {
         let fixture = try WorkerFixture()
         fixture.connections.backends = [makeBackend(id: "abs")]
         fixture.progressAPI.ebookPushError = URLError(.badServerResponse)
@@ -432,7 +434,7 @@ struct RecentlyPlayedSyncServiceTests {
         let result = await fixture.makeService().sync(trigger: .appLaunch)
 
         #expect(result.pushedItemCount == 0)
-        #expect(result.failedBackends.isEmpty)
+        #expect(result.failedBackends == ["Backend abs"])
         #expect(fixture.progressCache.recentlyPlayed.keys.contains(book.stableId))
     }
 
@@ -522,7 +524,7 @@ struct RecentlyPlayedSyncServiceTests {
 
     @Test func cancelledBackendFetchStopsRemainingBackendsWithoutMarkingFailures() async throws {
         let fixture = try WorkerFixture()
-        fixture.connections.backends = [makeBackend(id: "abs"), makeBackend(id: "emby", type: .emby)]
+        fixture.connections.backends = [makeBackend(id: "abs"), makeBackend(id: "second-abs")]
         fixture.progressAPI.progressByBackend["abs"] = .failure(CancellationError())
 
         let result = await fixture.makeService().sync(trigger: .appLaunch)
@@ -534,7 +536,7 @@ struct RecentlyPlayedSyncServiceTests {
 
     @Test func urlCancellationIsTreatedAsCancellationRatherThanFailure() async throws {
         let fixture = try WorkerFixture()
-        fixture.connections.backends = [makeBackend(id: "abs"), makeBackend(id: "emby", type: .emby)]
+        fixture.connections.backends = [makeBackend(id: "abs"), makeBackend(id: "second-abs")]
         fixture.progressAPI.progressByBackend["abs"] = .failure(URLError(.cancelled))
 
         let result = await fixture.makeService().sync(trigger: .appLaunch)
@@ -546,14 +548,139 @@ struct RecentlyPlayedSyncServiceTests {
 
     @Test func ordinaryBackendFailureIsRecordedAndTheNextBackendStillRuns() async throws {
         let fixture = try WorkerFixture()
-        fixture.connections.backends = [makeBackend(id: "abs"), makeBackend(id: "emby", type: .emby)]
+        fixture.connections.backends = [makeBackend(id: "abs"), makeBackend(id: "second-abs")]
         fixture.progressAPI.progressByBackend["abs"] = .failure(URLError(.timedOut))
 
         let result = await fixture.makeService().sync(trigger: .appLaunch)
 
         #expect(result.wasCancelled == false)
         #expect(result.failedBackends == ["Backend abs"])
-        #expect(fixture.progressAPI.queriedBackends == ["abs", "emby"])
+        #expect(fixture.progressAPI.queriedBackends == ["abs", "second-abs"])
+    }
+
+    @Test func refreshIncludesCompletedResetAndOlderItemsBeyondTwenty() async throws {
+        let fixture = try WorkerFixture()
+        fixture.connections.backends = [makeBackend(id: "abs")]
+        let books = (0..<25).map { makeBook(id: "book-\($0)") }
+        await fixture.store.upsertBooks(books)
+        fixture.libraryCache.allBooks = books
+        fixture.progressCache.stored[books[24].stableId] = .init(progress: 300, duration: 600, lastUpdated: 1_000)
+        fixture.progressAPI.progressByBackend["abs"] = .success((0..<25).map {
+            makeProgress(libraryItemId: "book-\($0)", currentTime: $0 == 24 ? 0 : 300,
+                         duration: 600, isFinished: $0 == 23, lastUpdateSeconds: 5_000 - Double($0))
+        })
+
+        let result = await fixture.makeService().sync(trigger: .homePullToRefresh)
+
+        #expect(result.pulledItemCount == 25)
+        #expect(await fixture.store.book(uniqueId: books[23].uniqueId)?.isFinished == true)
+        #expect(await fixture.store.book(uniqueId: books[24].uniqueId)?.currentTime == 0)
+        #expect(fixture.progressCache.stored[books[0].stableId]?.lastUpdated == 5_000)
+        #expect(fixture.progressAPI.audiobookPushes.isEmpty)
+    }
+
+    @Test func completedServerProgressRemovesAnEffectivelyFinishedBookFromContinueListening() async throws {
+        let fixture = try WorkerFixture()
+        fixture.connections.backends = [makeBackend(id: "abs")]
+        var book = makeBook(id: "finished", lastUpdate: Date(timeIntervalSince1970: 1_000))
+        book.currentTime = 600
+        await fixture.store.upsertBooks([book])
+        fixture.libraryCache.allBooks = [book]
+        fixture.progressCache.stored[book.stableId] = .init(progress: 600, duration: 600, lastUpdated: 1_000)
+        fixture.progressAPI.progressByBackend["abs"] = .success([
+            makeProgress(
+                libraryItemId: "finished",
+                currentTime: 600,
+                duration: 600,
+                progress: 1,
+                isFinished: false,
+                lastUpdateSeconds: 5_000
+            )
+        ])
+
+        let result = await fixture.makeService().sync(trigger: .homePullToRefresh)
+
+        #expect(result.pulledItemCount == 1)
+        #expect(await fixture.store.book(uniqueId: book.uniqueId)?.isFinished == true)
+        #expect(await fixture.store.continueListeningBooks(limit: 10).isEmpty)
+        #expect(fixture.progressCache.recentlyPlayed[book.stableId] == nil)
+    }
+
+    @Test func identicalItemIDsOnOtherServersAreNotReadOrPushed() async throws {
+        let fixture = try WorkerFixture()
+        fixture.connections.backends = [makeBackend(id: "abs")]
+        let own = makeBook(id: "shared")
+        var other = makeBook(id: "shared", backendId: "other")
+        other.providerId = UUID()
+        await fixture.store.upsertBooks([own, other])
+        fixture.progressCache.stored[other.stableId] = .init(progress: 500, duration: 600, lastUpdated: 9_000)
+        fixture.progressAPI.progressByBackend["abs"] = .success([
+            makeProgress(libraryItemId: "shared", currentTime: 200, duration: 600, lastUpdateSeconds: 5_000)
+        ])
+
+        let result = await fixture.makeService().sync(trigger: .homePullToRefresh)
+
+        #expect(result.pulledItemCount == 1)
+        #expect(fixture.progressCache.savedProgress[own.stableId] == 200)
+        #expect(fixture.progressCache.savedProgress[other.stableId] == nil)
+        #expect(fixture.progressAPI.audiobookPushes.isEmpty)
+    }
+
+    @Test func mediaServersNeverUseAudiobookshelfProgressAPI() async throws {
+        let fixture = try WorkerFixture()
+        fixture.connections.backends = [makeBackend(id: "jellyfin", type: .jellyfin), makeBackend(id: "emby", type: .emby)]
+        fixture.connections.connections = [makeConnection(type: .jellyfin), makeConnection(type: .emby)]
+        let native = SyncStrategyStub(id: "native", result: ProviderSyncResult(pulled: 2, pushed: 0, failedBackends: ["Offline source"]))
+        fixture.strategies.syncStrategies = [native]
+
+        let result = await fixture.makeService().sync(trigger: .homePullToRefresh)
+
+        #expect(fixture.progressAPI.queriedBackends.isEmpty)
+        #expect(result.pulledItemCount == 2)
+        #expect(result.failedBackends == ["Offline source"])
+        #expect(native.invocations.count == 1)
+    }
+
+    @Test func nativeProviderPullsIntoPersistenceWithoutUploadingStaleLocalState() async throws {
+        let fixture = try WorkerFixture()
+        let connection = makeConnection(type: .jellyfin)
+        fixture.connections.connections = [connection]
+        let provider = ProgressProviderStub(connection: connection)
+        provider.audiobookProgress = ProviderAudiobookProgress(
+            positionSeconds: 180, percentage: 0.3, trackIndex: nil, updatedAt: nil, readState: .reading
+        )
+        fixture.connections.providers[connection.id] = provider
+        let book = Book(id: "native", title: "Native", duration: 600, source: .jellyfin,
+                        providerId: connection.id, libraryId: "library")
+        await fixture.store.upsertBooks([book])
+        fixture.libraryCache.allBooks = [book]
+        let defaults = try #require(UserDefaults(suiteName: "NativeSync-\(UUID().uuidString)"))
+        let pending = PendingSyncQueueStore(defaults: defaults)
+        let strategy = NativeProgressSyncStrategy(
+            providerType: .jellyfin, source: .jellyfin, connections: fixture.connections,
+            books: fixture.store, progressRepository: fixture.store, libraryCache: fixture.libraryCache,
+            progressCache: fixture.progressCache, playbackState: fixture.playback, pendingSyncs: pending
+        )
+
+        let result = await strategy.sync(force: true, launchOptimized: false)
+
+        #expect(result.pulled == 1)
+        #expect(await fixture.store.book(uniqueId: book.uniqueId)?.currentTime == 180)
+        #expect(fixture.libraryCache.allBooks[0].currentTime == 180)
+        #expect(provider.playbackUpdates.isEmpty)
+
+        pending.enqueue(PendingServerSync(stableId: book.stableId, sourceRaw: "jellyfin", backendId: nil,
+                                          serverItemId: book.id, position: 400, duration: 600, updatedAt: 9000))
+        provider.audiobookProgress = ProviderAudiobookProgress(
+            positionSeconds: 0, percentage: 0, trackIndex: nil, updatedAt: nil, readState: .unspecified
+        )
+        let protected = await strategy.sync(force: true, launchOptimized: false)
+        #expect(protected.pulled == 0)
+        #expect(await fixture.store.book(uniqueId: book.uniqueId)?.currentTime == 180)
+        pending.removeAll()
+        let reset = await strategy.sync(force: true, launchOptimized: false)
+        #expect(reset.pulled == 1)
+        #expect(await fixture.store.book(uniqueId: book.uniqueId)?.currentTime == 0)
     }
 
     @Test func refreshesAudiobookSnapshotsForASmallLibrary() async throws {

--- a/ios/enveTests/StoreBackupTests.swift
+++ b/ios/enveTests/StoreBackupTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Testing
+
+@testable import enve
+
+@MainActor
+struct StoreBackupTests {
+    @Test func repeatedBackupsPreserveStoreAndJournal() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = root.appendingPathComponent("test.sqlite")
+        let journal = root.appendingPathComponent("test.sqlite-wal")
+        try Data("store".utf8).write(to: store)
+        try Data("journal".utf8).write(to: journal)
+
+        let first = try #require(StoreBackup.backup(storeURL: store, label: "Test"))
+        let second = try #require(StoreBackup.backup(storeURL: store, label: "Test"))
+        #expect(first != second)
+        #expect(try Data(contentsOf: first.appendingPathComponent("test.sqlite")) == Data("store".utf8))
+        #expect(try Data(contentsOf: second.appendingPathComponent("test.sqlite-wal")) == Data("journal".utf8))
+        #expect(FileManager.default.fileExists(atPath: store.path))
+        #expect(FileManager.default.fileExists(atPath: journal.path))
+        #expect(StoreBackup.existingBackups(in: root, label: "Test").count == 2)
+    }
+
+    @Test func failedBackupPreservesPreviousBackups() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = root.appendingPathComponent("test.sqlite")
+        try Data("store".utf8).write(to: store)
+        let label = String(repeating: "x", count: 220)
+        let previous = root.appendingPathComponent("\(label).corrupt-previous")
+        try FileManager.default.createDirectory(at: previous, withIntermediateDirectories: true)
+        #expect(StoreBackup.backup(storeURL: store, label: label, retainCount: 1) == nil)
+        #expect(FileManager.default.fileExists(atPath: previous.path))
+        #expect(try Data(contentsOf: store) == Data("store".utf8))
+    }
+}

--- a/ios/enveUITests/enveUITests.swift
+++ b/ios/enveUITests/enveUITests.swift
@@ -110,6 +110,30 @@ final class enveUISmokeTests: XCTestCase {
     }
 
     @MainActor
+    func testPassageAvailabilityPrompt() {
+        let app = launch(route: "player")
+        let readingOptions = app.buttons["Reading options"]
+        XCTAssertTrue(readingOptions.waitForExistence(timeout: 20))
+        readingOptions.tap()
+
+        let findPassage = app.buttons["Find this passage in ebook"]
+        XCTAssertTrue(findPassage.waitForExistence(timeout: 5))
+        findPassage.tap()
+
+        if #available(iOS 26.0, *) {
+            XCTAssertTrue(app.staticTexts["Link an ebook first"].waitForExistence(timeout: 5))
+            XCTAssertFalse(app.alerts["Update Required"].exists)
+        } else {
+            let alert = app.alerts["Update Required"]
+            XCTAssertTrue(alert.waitForExistence(timeout: 5))
+            XCTAssertTrue(alert.staticTexts["Finding passages in an ebook requires iOS 26.0 or newer."].exists)
+            alert.buttons["OK"].tap()
+            XCTAssertTrue(readingOptions.exists)
+            XCTAssertFalse(alert.exists)
+        }
+    }
+
+    @MainActor
     func testReaderPresentation() throws {
         let app = launch(route: "reader")
 


### PR DESCRIPTION
Updates both platform source snapshots and release notes, including artwork, provider progress synchronization, playback, and reader fixes. Includes iOS 26 on-device passage matching with an update-required prompt on older iOS versions.

Verification from the public source tree:
- iOS: 530 tests passed; one optional live-server test skipped.
- Passage availability UI tests passed on iOS 17 and iOS 26.
- Android: debug and minified release builds passed; 464 unit tests passed in each configuration.
- Pixel 7a: 38 instrumented regression tests passed, plus launch and navigation checks.
- Both provenance checks passed.

Live speech-to-ebook matching remains pending device verification. Existing warnings in unchanged iOS dependencies remain; Android reported no compiler warnings. Public history, licensing, CI, and branch protections are preserved.